### PR TITLE
docs: fix README link to STYLE-GUIDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These designs:
 ## 🎨 Style Guide
 
 We have created a **fantasy-themed mobile app style guide** for the Tibia Boss Tracker project, available here:  
-[📄 View Style Guide](./docs/design/style-guide.md)  
+[📄 View Style Guide](./docs/design/STYLE-GUIDE.md)  
 
 This style guide defines the **color palette**, **typography**, **layout rules**, **UI components**, and **iconography** to ensure consistent design throughout development.  
 It will be used in the **next steps of development** to create the actual theme and component files for the Expo (React Native) project, applying the defined values directly in code.


### PR DESCRIPTION
## 📄 Summary
This PR fixes the broken README link to the style guide by updating the reference from `style-guide.md` to `STYLE-GUIDE.md`.

## 🔄 Changes
- Updated README link to correctly point to `STYLE-GUIDE.md`.

## 🎯 Motivation
Ensures that the style guide is accessible from the README, preventing broken navigation for contributors and recruiters.

## 🔗 Related
N/A