### PR TITLE
feat(app): integrate boss chances API, sightings, and major UI updates

### DIFF
--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -8,6 +8,7 @@ import styled from "styled-components/native";
 
 import { BossListItem } from "@/components/ui/BossListItem";
 import { LootRow } from "@/components/ui/LootRow";
+import SightingListItem from "@/components/ui/SightingListItem";
 import StaticTibiaMap from "@/components/ui/StaticTibiaMap";
 import type { BossChanceItem, BossChanceLevel } from "@/data/chances";
 import { useRecentSightings } from "@/data/sightings/hooks";
@@ -69,6 +70,7 @@ const FloatingLabelText = styled.Text(({ theme }) => ({
   color: theme.tokens.colors.text,
   fontSize: 12,
 }));
+
 
 export default function BossDetail() {
   const { boss, id } = useLocalSearchParams<{ boss?: string; id?: string }>();
@@ -153,9 +155,12 @@ export default function BossDetail() {
               .filter((s) => s.bossName === parsed.name)
               .slice(0, 5)
               .map((s) => (
-                <Text key={s.id} style={{ color: '#b0b0b0', marginBottom: 6 }}>
-                  {(s.playerName ?? 'Someone')} • {s.createdAt ? new Date(s.createdAt.toDate?.() ?? Date.now()).toLocaleTimeString() : 'just now'}
-                </Text>
+                <SightingListItem
+                  key={s.id}
+                  status={s.status as any}
+                  title={s.playerName ?? 'Someone'}
+                  subtitle={s.createdAt ? new Date(s.createdAt.toDate?.() ?? Date.now()).toLocaleTimeString() : 'just now'}
+                />
               ))
           ) : (
             <Text style={{ color: '#b0b0b0' }}>No recent reports</Text>

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -6,11 +6,13 @@ import { useLayoutEffect, useMemo, useState } from "react";
 import { Text, View } from "react-native";
 import styled from "styled-components/native";
 
+import { BossListItem } from "@/components/ui/BossListItem";
 import { LootRow } from "@/components/ui/LootRow";
 import StaticTibiaMap from "@/components/ui/StaticTibiaMap";
 import type { BossChanceItem, BossChanceLevel } from "@/data/chances";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
+import { getBossImageUrl } from "@/utils/images";
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 
 
@@ -21,12 +23,20 @@ const Section = styled.View(({ theme }) => ({
   marginBottom: 12,
 }));
 
+const SectionTitle = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontSize: theme.tokens.typography.sizes.h3,
+  fontFamily: theme.tokens.typography.fonts.title,
+  fontWeight: 'bold',
+  marginBottom: 8,
+}));
+
 const Badge = styled.Text<{ level: BossChanceLevel | undefined }>(({ theme, level }) => {
   const map: Record<string, string> = {
     high: theme.tokens.colors.success,
     medium: theme.tokens.colors.warning,
     low: '#7a7a7a',
-    'Lost Track': "#555",
+    'lost track': "#555",
     'no chance': theme.tokens.colors.danger,
   } as const;
   const bg = (level && map[level]) || theme.tokens.colors.backgroundDark;
@@ -72,7 +82,7 @@ export default function BossDetail() {
   }, [boss]);
 
   useLayoutEffect(() => {
-    navigation.setOptions({ title: parsed?.name ?? id ?? "Boss Detail" });
+    navigation.setOptions({ title: "Boss Detail" });
   }, [parsed, id, navigation]);
 
   const [labelText, setLabelText] = useState("");
@@ -97,25 +107,26 @@ export default function BossDetail() {
     labelTranslate.value = withTiming(0, { duration: 180 });
   };
 
+  if (!parsed) return null;
   return (
     initializing ? null : !user ? (
       <Redirect href="/onboarding" />
     ) : (
       <Screen scrollable>
+        <BossListItem
+          name={parsed.name}
+          chance={parsed.chance}
+          imageUrl={getBossImageUrl(parsed.name)}
+          onPress={() => { }}
+          city={parsed.city}
+          daysSince={parsed.daysSince}
+        />
         <Section>
-          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Text style={{ color: "#fff", fontSize: 18 }}>{parsed?.city ?? 'Unknown'}</Text>
-            <Badge level={parsed?.chance as BossChanceLevel}>{parsed?.chance ?? 'Unknown'}</Badge>
-          </View>
-        </Section>
-
-        <Section>
-          <Text style={{ color: "#fff", marginBottom: 6 }}>Location</Text>
+          <SectionTitle>Location</SectionTitle>
           {parsed?.location?.length ? (
             <>
               {parsed.location.map((coord, idx) => (
                 <View key={`${coord}-${idx}`} style={{ marginBottom: 8 }}>
-                  <Text style={{ color: "#b0b0b0", marginBottom: 6 }}>{coord}</Text>
                   <StaticTibiaMap coord={coord} height={250} />
                 </View>
               ))}
@@ -126,14 +137,12 @@ export default function BossDetail() {
         </Section>
 
         <Section>
-          <Text style={{ color: "#fff", marginBottom: 6 }}>Last seen</Text>
-          <Text style={{ color: "#b0b0b0" }}>
-            {parsed?.lastSeen ?? 'Unknown'}{typeof parsed?.daysSince === 'number' ? ` • ${parsed?.daysSince} days ago` : ''}
-          </Text>
+          <SectionTitle>Last sightings</SectionTitle>
+          
         </Section>
 
         <Section>
-          <Text style={{ color: "#fff", marginBottom: 6, textAlign: 'center' }}>Loot</Text>
+          <SectionTitle>Notable Loot</SectionTitle>
           {parsed?.loots?.length ? (
             <>
               <LootRow items={parsed.loots} onSelect={handleSelect} />
@@ -146,7 +155,7 @@ export default function BossDetail() {
               </FloatingLabel>
             </>
           ) : (
-            <Text style={{ color: "#b0b0b0", textAlign: 'center' }}>Unknown</Text>
+            <Text style={{ color: "#b0b0b0", textAlign: 'center' }}>None</Text>
           )}
         </Section>
 
@@ -158,7 +167,7 @@ export default function BossDetail() {
               .open("bossStatus", { bossId: parsed?.id ?? (parsed?.name ?? 'unknown'), bossName: parsed?.name ?? 'Unknown' })
           }
         >
-          <ButtonText>Mark as Watched</ButtonText>
+          <ButtonText>Check this Boss</ButtonText>
         </Button>
       </Screen>
     )

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -2,13 +2,16 @@
 import { Button, ButtonText } from "@/components/ui/Button";
 import { Screen } from "@/components/ui/Screen";
 import { Redirect, useLocalSearchParams, useNavigation } from "expo-router";
-import { useLayoutEffect } from "react";
-import { Text } from "react-native";
+import { useLayoutEffect, useMemo } from "react";
+import { FlatList, Text, View } from "react-native";
 import styled from "styled-components/native";
 
 import StaticTibiaMap from "@/components/ui/StaticTibiaMap";
+import type { BossChanceItem, BossChanceLevel } from "@/data/chances";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
+import { getLootImageUrl } from "@/utils/images";
+import { Image } from "expo-image";
 
 
 const Section = styled.View(({ theme }) => ({
@@ -18,14 +21,48 @@ const Section = styled.View(({ theme }) => ({
   marginBottom: 12,
 }));
 
+const Badge = styled.Text<{ level: BossChanceLevel | undefined }>(({ theme, level }) => {
+  const map: Record<string, string> = {
+    high: theme.tokens.colors.success,
+    medium: theme.tokens.colors.warning,
+    low: theme.tokens.colors.danger,
+    'Lost Track': theme.tokens.colors.danger,
+    'no chance': theme.tokens.colors.danger,
+  } as const;
+  const bg = (level && map[level]) || theme.tokens.colors.backgroundDark;
+  return {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: theme.tokens.radius,
+    backgroundColor: bg,
+    color: theme.tokens.colors.text,
+    overflow: 'hidden',
+  } as any;
+});
+
+const LootImage = styled(Image)(({ theme }) => ({
+  width: 48,
+  height: 48,
+  marginHorizontal: 8,
+}));
+
 export default function BossDetail() {
-  const { name } = useLocalSearchParams<{ name?: string }>();
+  const { boss, id } = useLocalSearchParams<{ boss?: string; id?: string }>();
   const navigation = useNavigation();
   const { user, initializing } = useAuth();
 
+  const parsed: BossChanceItem | null = useMemo(() => {
+    try {
+      return boss ? (JSON.parse(boss) as BossChanceItem) : null;
+    } catch {
+      return null;
+    }
+  }, [boss]);
+
   useLayoutEffect(() => {
-    navigation.setOptions({ title: name ?? "Boss Detail" });
-  }, [name, navigation]);
+    navigation.setOptions({ title: parsed?.name ?? id ?? "Boss Detail" });
+  }, [parsed, id, navigation]);
 
   return (
     initializing ? null : !user ? (
@@ -33,20 +70,58 @@ export default function BossDetail() {
     ) : (
     <Screen>
       <Section>
-        <Text style={{ color: "#fff" }}>Location: Edron, Dragon Lair</Text>
-        <StaticTibiaMap coord="32968,32400,12:2" height={350} />
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Text style={{ color: "#fff", fontSize: 18 }}>{parsed?.city ?? 'Unknown'}</Text>
+          <Badge level={parsed?.chance as BossChanceLevel}>{parsed?.chance ?? 'Unknown'}</Badge>
+        </View>
       </Section>
 
       <Section>
-        <Text style={{ color: "#fff", marginBottom: 6 }}>Last Sightings</Text>
-        <Text style={{ color: "#b0b0b0" }}>2025-08-08 10:21 — Vinicius</Text>
+        <Text style={{ color: "#fff", marginBottom: 6 }}>Location</Text>
+        {parsed?.location?.length ? (
+          <>
+            {parsed.location.map((coord, idx) => (
+              <View key={`${coord}-${idx}`} style={{ marginBottom: 8 }}>
+                <Text style={{ color: "#b0b0b0", marginBottom: 6 }}>{coord}</Text>
+                <StaticTibiaMap coord={coord} height={250} />
+              </View>
+            ))}
+          </>
+        ) : (
+          <Text style={{ color: "#b0b0b0" }}>Unknown</Text>
+        )}
       </Section>
 
       <Section>
-        <Text style={{ color: "#fff", marginBottom: 6 }}>Loot</Text>
+        <Text style={{ color: "#fff", marginBottom: 6 }}>Last seen</Text>
         <Text style={{ color: "#b0b0b0" }}>
-          Dragon Scale • Gold • Boots of Haste
+          {parsed?.lastSeen ?? 'Unknown'}{typeof parsed?.daysSince === 'number' ? ` • ${parsed?.daysSince} days ago` : ''}
         </Text>
+      </Section>
+
+      <Section>
+        <Text style={{ color: "#fff", marginBottom: 6, textAlign: 'center' }}>Loot</Text>
+        {parsed?.loots?.length ? (
+          <FlatList
+            data={parsed.loots}
+            keyExtractor={(i) => i}
+            renderItem={({ item }) => (
+              <View style={{ alignItems: 'center' }}>
+                <LootImage
+                  source={{ uri: getLootImageUrl(item) }}
+                  contentFit="contain"
+                  accessibilityLabel={item}
+                />
+                <Text style={{ color: '#b0b0b0', marginTop: 4 }}>{item}</Text>
+              </View>
+            )}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ paddingHorizontal: 8 }}
+          />
+        ) : (
+          <Text style={{ color: "#b0b0b0", textAlign: 'center' }}>Unknown</Text>
+        )}
       </Section>
 
       <Button
@@ -54,7 +129,7 @@ export default function BossDetail() {
         onPress={() =>
           useModals
             .getState()
-            .open("bossStatus", { bossId: "orshabaal", bossName: "Orshabaal" })
+            .open("bossStatus", { bossId: parsed?.id ?? (parsed?.name ?? 'unknown'), bossName: parsed?.name ?? 'Unknown' })
         }
       >
         <ButtonText>Mark as Watched</ButtonText>

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -129,6 +129,7 @@ export default function BossDetail() {
           onPress={() => { }}
           city={parsed.city}
           daysSince={parsed.daysSince}
+          killed={Boolean(recent?.find((s) => s.bossName === parsed.name && s.status === 'killed'))}
         />
         <Section>
           <SectionTitle>Location</SectionTitle>

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -25,8 +25,8 @@ const Badge = styled.Text<{ level: BossChanceLevel | undefined }>(({ theme, leve
   const map: Record<string, string> = {
     high: theme.tokens.colors.success,
     medium: theme.tokens.colors.warning,
-    low: theme.tokens.colors.danger,
-    'Lost Track': theme.tokens.colors.danger,
+    low: '#7a7a7a',
+    'Lost Track': "#555",
     'no chance': theme.tokens.colors.danger,
   } as const;
   const bg = (level && map[level]) || theme.tokens.colors.backgroundDark;
@@ -36,8 +36,11 @@ const Badge = styled.Text<{ level: BossChanceLevel | undefined }>(({ theme, leve
     paddingVertical: 4,
     borderRadius: theme.tokens.radius,
     backgroundColor: bg,
-    color: theme.tokens.colors.text,
     overflow: 'hidden',
+    color: '#111',
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    fontSize: 12,
   } as any;
 });
 
@@ -68,73 +71,73 @@ export default function BossDetail() {
     initializing ? null : !user ? (
       <Redirect href="/onboarding" />
     ) : (
-    <Screen>
-      <Section>
-        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Text style={{ color: "#fff", fontSize: 18 }}>{parsed?.city ?? 'Unknown'}</Text>
-          <Badge level={parsed?.chance as BossChanceLevel}>{parsed?.chance ?? 'Unknown'}</Badge>
-        </View>
-      </Section>
+      <Screen scrollable>
+        <Section>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Text style={{ color: "#fff", fontSize: 18 }}>{parsed?.city ?? 'Unknown'}</Text>
+            <Badge level={parsed?.chance as BossChanceLevel}>{parsed?.chance ?? 'Unknown'}</Badge>
+          </View>
+        </Section>
 
-      <Section>
-        <Text style={{ color: "#fff", marginBottom: 6 }}>Location</Text>
-        {parsed?.location?.length ? (
-          <>
-            {parsed.location.map((coord, idx) => (
-              <View key={`${coord}-${idx}`} style={{ marginBottom: 8 }}>
-                <Text style={{ color: "#b0b0b0", marginBottom: 6 }}>{coord}</Text>
-                <StaticTibiaMap coord={coord} height={250} />
-              </View>
-            ))}
-          </>
-        ) : (
-          <Text style={{ color: "#b0b0b0" }}>Unknown</Text>
-        )}
-      </Section>
+        <Section>
+          <Text style={{ color: "#fff", marginBottom: 6 }}>Location</Text>
+          {parsed?.location?.length ? (
+            <>
+              {parsed.location.map((coord, idx) => (
+                <View key={`${coord}-${idx}`} style={{ marginBottom: 8 }}>
+                  <Text style={{ color: "#b0b0b0", marginBottom: 6 }}>{coord}</Text>
+                  <StaticTibiaMap coord={coord} height={250} />
+                </View>
+              ))}
+            </>
+          ) : (
+            <Text style={{ color: "#b0b0b0" }}>Unknown</Text>
+          )}
+        </Section>
 
-      <Section>
-        <Text style={{ color: "#fff", marginBottom: 6 }}>Last seen</Text>
-        <Text style={{ color: "#b0b0b0" }}>
-          {parsed?.lastSeen ?? 'Unknown'}{typeof parsed?.daysSince === 'number' ? ` • ${parsed?.daysSince} days ago` : ''}
-        </Text>
-      </Section>
+        <Section>
+          <Text style={{ color: "#fff", marginBottom: 6 }}>Last seen</Text>
+          <Text style={{ color: "#b0b0b0" }}>
+            {parsed?.lastSeen ?? 'Unknown'}{typeof parsed?.daysSince === 'number' ? ` • ${parsed?.daysSince} days ago` : ''}
+          </Text>
+        </Section>
 
-      <Section>
-        <Text style={{ color: "#fff", marginBottom: 6, textAlign: 'center' }}>Loot</Text>
-        {parsed?.loots?.length ? (
-          <FlatList
-            data={parsed.loots}
-            keyExtractor={(i) => i}
-            renderItem={({ item }) => (
-              <View style={{ alignItems: 'center' }}>
-                <LootImage
-                  source={{ uri: getLootImageUrl(item) }}
-                  contentFit="contain"
-                  accessibilityLabel={item}
-                />
-                <Text style={{ color: '#b0b0b0', marginTop: 4 }}>{item}</Text>
-              </View>
-            )}
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingHorizontal: 8 }}
-          />
-        ) : (
-          <Text style={{ color: "#b0b0b0", textAlign: 'center' }}>Unknown</Text>
-        )}
-      </Section>
+        <Section>
+          <Text style={{ color: "#fff", marginBottom: 6, textAlign: 'center' }}>Loot</Text>
+          {parsed?.loots?.length ? (
+            <FlatList
+              data={parsed.loots}
+              keyExtractor={(i) => i}
+              renderItem={({ item }) => (
+                <View style={{ alignItems: 'center' }}>
+                  <LootImage
+                    source={{ uri: getLootImageUrl(item) }}
+                    contentFit="contain"
+                    accessibilityLabel={item}
+                  />
+                  <Text style={{ color: '#b0b0b0', marginTop: 4 }}>{item}</Text>
+                </View>
+              )}
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={{ paddingHorizontal: 8 }}
+            />
+          ) : (
+            <Text style={{ color: "#b0b0b0", textAlign: 'center' }}>Unknown</Text>
+          )}
+        </Section>
 
-      <Button
-        variant="primary"
-        onPress={() =>
-          useModals
-            .getState()
-            .open("bossStatus", { bossId: parsed?.id ?? (parsed?.name ?? 'unknown'), bossName: parsed?.name ?? 'Unknown' })
-        }
-      >
-        <ButtonText>Mark as Watched</ButtonText>
-      </Button>
-    </Screen>
+        <Button
+          variant="primary"
+          onPress={() =>
+            useModals
+              .getState()
+              .open("bossStatus", { bossId: parsed?.id ?? (parsed?.name ?? 'unknown'), bossName: parsed?.name ?? 'Unknown' })
+          }
+        >
+          <ButtonText>Mark as Watched</ButtonText>
+        </Button>
+      </Screen>
     )
   );
 }

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -10,6 +10,8 @@ import { BossListItem } from "@/components/ui/BossListItem";
 import { LootRow } from "@/components/ui/LootRow";
 import StaticTibiaMap from "@/components/ui/StaticTibiaMap";
 import type { BossChanceItem, BossChanceLevel } from "@/data/chances";
+import { useRecentSightings } from "@/data/sightings/hooks";
+import { loadSelectedWorld } from "@/data/worlds/hooks";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
 import { getBossImageUrl } from "@/utils/images";
@@ -88,6 +90,8 @@ export default function BossDetail() {
   const [labelText, setLabelText] = useState("");
   const labelOpacity = useSharedValue(0);
   const labelTranslate = useSharedValue(8);
+  const [world, setWorld] = useState<string | null>(null);
+  const { data: recent } = useRecentSightings(world, 10);
 
   const labelStyle = useAnimatedStyle(() => ({
     opacity: labelOpacity.value,
@@ -106,6 +110,11 @@ export default function BossDetail() {
     labelOpacity.value = withTiming(1, { duration: 180 });
     labelTranslate.value = withTiming(0, { duration: 180 });
   };
+
+  // Load current world to filter recent sightings
+  useLayoutEffect(() => {
+    loadSelectedWorld().then(setWorld);
+  }, []);
 
   if (!parsed) return null;
   return (
@@ -138,7 +147,18 @@ export default function BossDetail() {
 
         <Section>
           <SectionTitle>Last sightings</SectionTitle>
-          
+          {recent?.length ? (
+            recent
+              .filter((s) => s.bossName === parsed.name)
+              .slice(0, 5)
+              .map((s) => (
+                <Text key={s.id} style={{ color: '#b0b0b0', marginBottom: 6 }}>
+                  {(s.playerName ?? 'Someone')} • {s.createdAt ? new Date(s.createdAt.toDate?.() ?? Date.now()).toLocaleTimeString() : 'just now'}
+                </Text>
+              ))
+          ) : (
+            <Text style={{ color: '#b0b0b0' }}>No recent reports</Text>
+          )}
         </Section>
 
         <Section>

--- a/app/bosses/[id].tsx
+++ b/app/bosses/[id].tsx
@@ -6,6 +6,7 @@ import { useLayoutEffect } from "react";
 import { Text } from "react-native";
 import styled from "styled-components/native";
 
+import StaticTibiaMap from "@/components/ui/StaticTibiaMap";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
 
@@ -33,6 +34,7 @@ export default function BossDetail() {
     <Screen>
       <Section>
         <Text style={{ color: "#fff" }}>Location: Edron, Dragon Lair</Text>
+        <StaticTibiaMap coord="32968,32400,12:2" height={350} />
       </Section>
 
       <Section>

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -95,15 +95,6 @@ const BossInfo = styled.View(() => ({
   flex: 1,
 }));
 
-const MOCK_KILLED = [
-  { id: "draptor", name: "Draptor", chance: "High" },
-  { id: "ghazbaran", name: "Ghazbaran", chance: "Low" },
-];
-
-const MOCK_LIST = [
-  { id: "orkus", name: "Orshabaal", chancePercent: 72 },
-  { id: "morg", name: "Morgaroth", chancePercent: 38 },
-];
 
 export const options = { title: "Bosses" };
 
@@ -162,6 +153,8 @@ export default function BossList() {
   }, [navigation, theme, open]);
   if (initializing) return null;
   if (!user) return <Redirect href="/onboarding" />;
+  const killedYesterday = chances.filter((c) => c.daysSince === 1);
+  const killedYesterdayData = killedYesterday.map((c) => ({ ...c, id: c.id ?? c.name }));
   return (
     <Screen>
 
@@ -174,27 +167,31 @@ export default function BossList() {
         keyExtractor={(i) => i.id}
         ListHeaderComponent={
           <View>
-            <SectionTitle>Bosses Killed Yesterday</SectionTitle>
-            <Horizontal
-              data={MOCK_KILLED}
-              keyExtractor={(i: any) => i.id}
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              renderItem={({ item }: any) => (
-                <Card style={{ marginRight: 12, width: 200 }}>
-                  <BossRow>
-                    <BossAvatar
-                      source={{ uri: getBossImageUrl(item.name) }}
-                      contentFit="cover"
-                    />
-                    <BossInfo>
-                      <BossName numberOfLines={1}>{item.name}</BossName>
-                    </BossInfo>
-                  </BossRow>
-                </Card>
-              )}
-              style={{ marginBottom: 12 }}
-            />
+            {killedYesterdayData.length > 0 && (
+              <View style={{ marginBottom: 12 }}>
+                <SectionTitle>Bosses Killed Yesterday</SectionTitle>
+                <Horizontal
+                  data={killedYesterdayData}
+                  keyExtractor={(i: any) => i.id}
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  renderItem={({ item }: any) => (
+                    <Card style={{ marginRight: 12, width: 200 }}>
+                      <BossRow>
+                        <BossAvatar
+                          source={{ uri: getBossImageUrl(item.name) }}
+                          contentFit="cover"
+                        />
+                        <BossInfo>
+                          <BossName numberOfLines={1}>{item.name}</BossName>
+                        </BossInfo>
+                      </BossRow>
+                    </Card>
+                  )}
+                  style={{ marginBottom: 12 }}
+                />
+              </View>
+            )}
             <PageHeader>
               <PageTitle>Today’s Bosses</PageTitle>
               <PageSubtitle>{todayLabel}</PageSubtitle>

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -1,5 +1,4 @@
 // app/bosses/index.tsx
-import { Button, ButtonText } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Screen } from "@/components/ui/Screen";
 import { getBossImageUrl } from "@/utils/images";
@@ -10,6 +9,7 @@ import { useLayoutEffect } from "react";
 import { FlatList, TouchableOpacity, View } from "react-native";
 import styled from "styled-components/native";
 
+import { BossListItem } from "@/components/ui/BossListItem";
 import { loadSelectedWorld, useBossChances } from "@/data/worlds/hooks";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
@@ -196,35 +196,25 @@ export default function BossList() {
               style={{ marginBottom: 12 }}
             />
             <PageHeader>
-              <PageTitle>Bosses for Today</PageTitle>
+              <PageTitle>Today’s Bosses</PageTitle>
               <PageSubtitle>{todayLabel}</PageSubtitle>
             </PageHeader>
           </View>
         }
         renderItem={({ item }) => (
-          <TouchableOpacity
-            delayPressIn={100}
-            onPress={() => router.push({ pathname: "/bosses/[id]", params: { id: item.id, boss: JSON.stringify(item) } })}
-          >
-            <Card pointerEvents="none">
-              <BossRow>
-                <BossAvatar
-                  source={{ uri: getBossImageUrl(item.name) }}
-                  contentFit="cover"
-                />
-                <BossInfo>
-                  <BossName numberOfLines={1}>{item.name}</BossName>
-                  <Chance>
-                    {item.chance ?? 'Unknown'}
-                  </Chance>
-                </BossInfo>
-              </BossRow>
-              <View style={{ height: 8 }} />
-              <Button variant="primary">
-                <ButtonText>Check</ButtonText>
-              </Button>
-            </Card>
-          </TouchableOpacity>
+          <BossListItem
+            name={item.name}
+            city={item.city}
+            daysSince={item.daysSince}
+            chance={(item.chance ?? 'low') as any}
+            imageUrl={getBossImageUrl(item.name)}
+            onPress={() =>
+              router.push({
+                pathname: '/bosses/[id]',
+                params: { id: item.id, boss: JSON.stringify(item) },
+              })
+            }
+          />
         )}
         contentContainerStyle={{ paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -5,15 +5,18 @@ import { getBossImageUrl } from "@/utils/images";
 import { format } from "date-fns";
 import { Image } from "expo-image";
 import { Redirect, router, useNavigation } from "expo-router";
-import { useLayoutEffect } from "react";
+import { useCallback, useLayoutEffect, useMemo } from "react";
 import { FlatList, TouchableOpacity, View } from "react-native";
 import styled from "styled-components/native";
 
 import { BossListItem } from "@/components/ui/BossListItem";
+import { BOSSES_FILTERS_KEY } from "@/data/cache/keys";
+import { getWithTTL, setWithTTL } from "@/data/cache/storage";
 import { loadSelectedWorld, useBossChances } from "@/data/worlds/hooks";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
 import { Ionicons } from "@expo/vector-icons";
+import { useFocusEffect } from "@react-navigation/native";
 import { useEffect, useState } from "react";
 import { useTheme } from "styled-components/native";
 
@@ -95,6 +98,31 @@ const BossInfo = styled.View(() => ({
   flex: 1,
 }));
 
+const ChipRow = styled.View(({ theme }) => ({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  marginBottom: theme.tokens.spacing(1.5),
+}));
+
+const Chip = styled.TouchableOpacity(({ theme }) => ({
+  flexDirection: 'row',
+  alignItems: 'center',
+  paddingVertical: 6,
+  paddingHorizontal: 10,
+  borderRadius: 999,
+  borderWidth: 1,
+  marginRight: theme.tokens.spacing(1),
+  marginBottom: theme.tokens.spacing(1),
+  backgroundColor: theme.tokens.colors.card,
+  borderColor: 'rgba(255,255,255,0.12)',
+}));
+
+const ChipText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontFamily: theme.tokens.typography.fonts.body,
+  marginRight: 6,
+}));
+
 
 export const options = { title: "Bosses" };
 
@@ -110,6 +138,8 @@ export default function BossList() {
   const { data: chances, loading: chancesLoading } = useBossChances(selectedWorld);
 
   const { open } = useModals();
+  const [filters, setFilters] = useState<{ chance: 'low' | 'medium' | 'high' | null; city: string | null; search: string | null } | null>(null);
+  const [searchInput, setSearchInput] = useState<string>("");
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -151,19 +181,106 @@ export default function BossList() {
       ),
     });
   }, [navigation, theme, open]);
+  const loadFilters = useCallback(async () => {
+    const saved = await getWithTTL<any>(BOSSES_FILTERS_KEY, Number.MAX_SAFE_INTEGER);
+    setFilters({
+      chance: (saved?.chance as any) ?? null,
+      city: typeof saved?.city === 'string' ? saved.city : null,
+      search: typeof saved?.search === 'string' && saved.search.trim() ? saved.search : null,
+    });
+    setSearchInput(typeof saved?.search === 'string' ? saved.search : "");
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadFilters();
+    }, [loadFilters])
+  );
   if (initializing) return null;
   if (!user) return <Redirect href="/onboarding" />;
   const killedYesterday = chances.filter((c) => c.daysSince === 1);
   const killedYesterdayData = killedYesterday.map((c) => ({ ...c, id: c.id ?? c.name }));
+  const filteredChances = useMemo(() => {
+    let list = chances;
+    if (filters?.chance) {
+      list = list.filter((i) => (i.chance?.toLowerCase?.() ?? '') === filters.chance);
+    }
+    if (filters?.city) {
+      list = list.filter((i) => i.city === filters.city);
+    }
+    if (filters?.search && filters.search.trim()) {
+      const s = filters.search.trim().toLowerCase();
+      list = list.filter((i) => i.name.toLowerCase().includes(s));
+    }
+    return list;
+  }, [chances, filters]);
+
+  const removeFilter = useCallback(async (key: 'chance' | 'city' | 'search') => {
+    const saved = await getWithTTL<any>(BOSSES_FILTERS_KEY, Number.MAX_SAFE_INTEGER);
+    const next = { ...(saved ?? {}), [key]: null } as any;
+    if (key === 'search') next.search = null;
+    await setWithTTL(BOSSES_FILTERS_KEY, next);
+    await loadFilters();
+  }, [loadFilters]);
   return (
     <Screen>
 
       <TopBar>
-        <Search placeholder="Search bosses..." placeholderTextColor="#888" />
+        <Search
+          placeholder="Search bosses..."
+          placeholderTextColor="#888"
+          value={searchInput}
+          onChangeText={setSearchInput}
+          returnKeyType="search"
+          onSubmitEditing={async () => {
+            const term = searchInput.trim();
+            const saved = await getWithTTL<any>(BOSSES_FILTERS_KEY, Number.MAX_SAFE_INTEGER);
+            await setWithTTL(BOSSES_FILTERS_KEY, {
+              ...(saved ?? {}),
+              search: term.length ? term : null,
+            });
+            await loadFilters();
+          }}
+        />
       </TopBar>
 
+      {filters && (filters.chance || filters.city || (filters.search && filters.search.trim())) ? (
+        <ChipRow>
+          {filters.search && (
+            <Chip onPress={() => removeFilter('search')}>
+              <ChipText>Search: {filters.search}</ChipText>
+              <Ionicons name="close" size={16} color={theme.tokens.colors.text} />
+            </Chip>
+          )}
+          {filters.chance && (
+            <Chip onPress={() => removeFilter('chance')}>
+              <ChipText>
+                Chance: {
+                  filters.chance === 'low'
+                    ? 'Low'
+                    : filters.chance === 'medium'
+                    ? 'Mid'
+                    : filters.chance === 'high'
+                    ? 'High'
+                    : filters.chance === 'no chance'
+                    ? 'No Chance'
+                    : 'Lost Track'
+                }
+              </ChipText>
+              <Ionicons name="close" size={16} color={theme.tokens.colors.text} />
+            </Chip>
+          )}
+          {filters.city && (
+            <Chip onPress={() => removeFilter('city')}>
+              <ChipText>City: {filters.city}</ChipText>
+              <Ionicons name="close" size={16} color={theme.tokens.colors.text} />
+            </Chip>
+          )}
+        </ChipRow>
+      ) : null}
+
       <FlatList
-        data={chances.map((c) => ({ ...c, id: c.id ?? c.name }))}
+        data={filteredChances.map((c) => ({ ...c, id: c.id ?? c.name }))}
         keyExtractor={(i) => i.id}
         ListHeaderComponent={
           <View>

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -12,6 +12,7 @@ import styled from "styled-components/native";
 import { BossListItem } from "@/components/ui/BossListItem";
 import { BOSSES_FILTERS_KEY } from "@/data/cache/keys";
 import { getWithTTL, setWithTTL } from "@/data/cache/storage";
+import { useRecentSightings } from "@/data/sightings/hooks";
 import { loadSelectedWorld, useBossChances } from "@/data/worlds/hooks";
 import { useAuth } from "@/state/auth";
 import { useModals } from "@/state/modals";
@@ -136,6 +137,7 @@ export default function BossList() {
     loadSelectedWorld().then((w) => setSelectedWorld(w));
   }, []);
   const { data: chances, loading: chancesLoading } = useBossChances(selectedWorld);
+  const { killedSet } = useRecentSightings(selectedWorld, 200);
 
   const { open } = useModals();
   const [filters, setFilters] = useState<{ chance: 'low' | 'medium' | 'high' | null; city: string | null; search: string | null } | null>(null);
@@ -322,6 +324,7 @@ export default function BossList() {
             daysSince={item.daysSince}
             chance={(item.chance ?? 'low') as any}
             imageUrl={getBossImageUrl(item.name)}
+            killed={killedSet?.has?.(item.name)}
             onPress={() =>
               router.push({
                 pathname: '/bosses/[id]',

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -202,26 +202,29 @@ export default function BossList() {
           </View>
         }
         renderItem={({ item }) => (
-          <Card
-            onTouchEnd={() => router.push({ pathname: "/bosses/[id]", params: { id: item.id, boss: JSON.stringify(item) } })}
+          <TouchableOpacity
+            delayPressIn={100}
+            onPress={() => router.push({ pathname: "/bosses/[id]", params: { id: item.id, boss: JSON.stringify(item) } })}
           >
-            <BossRow>
-              <BossAvatar
-                source={{ uri: getBossImageUrl(item.name) }}
-                contentFit="cover"
-              />
-              <BossInfo>
-                <BossName numberOfLines={1}>{item.name}</BossName>
-                <Chance>
-                  {item.chance ?? 'Unknown'}
-                </Chance>
-              </BossInfo>
-            </BossRow>
-            <View style={{ height: 8 }} />
-            <Button variant="primary">
-              <ButtonText>Check</ButtonText>
-            </Button>
-          </Card>
+            <Card pointerEvents="none">
+              <BossRow>
+                <BossAvatar
+                  source={{ uri: getBossImageUrl(item.name) }}
+                  contentFit="cover"
+                />
+                <BossInfo>
+                  <BossName numberOfLines={1}>{item.name}</BossName>
+                  <Chance>
+                    {item.chance ?? 'Unknown'}
+                  </Chance>
+                </BossInfo>
+              </BossRow>
+              <View style={{ height: 8 }} />
+              <Button variant="primary">
+                <ButtonText>Check</ButtonText>
+              </Button>
+            </Card>
+          </TouchableOpacity>
         )}
         contentContainerStyle={{ paddingBottom: 24 }}
         showsVerticalScrollIndicator={false}

--- a/app/bosses/index.tsx
+++ b/app/bosses/index.tsx
@@ -138,7 +138,7 @@ export default function BossList() {
               color={theme.tokens.colors.text}
             />
           </TouchableOpacity>
-         
+
           <TouchableOpacity
             onPress={() => open("timeline", true)}
             accessibilityLabel="Open timeline"
@@ -157,10 +157,7 @@ export default function BossList() {
   if (!user) return <Redirect href="/onboarding" />;
   return (
     <Screen>
-      <PageHeader>
-        <PageTitle>Bosses for Today</PageTitle>
-        <PageSubtitle>{todayLabel}</PageSubtitle>
-      </PageHeader>
+
       <TopBar>
         <Search placeholder="Search bosses..." placeholderTextColor="#888" />
       </TopBar>
@@ -191,6 +188,10 @@ export default function BossList() {
               )}
               style={{ marginBottom: 12 }}
             />
+            <PageHeader>
+              <PageTitle>Bosses for Today</PageTitle>
+              <PageSubtitle>{todayLabel}</PageSubtitle>
+            </PageHeader>
           </View>
         }
         renderItem={({ item }) => (

--- a/app/filter.tsx
+++ b/app/filter.tsx
@@ -1,7 +1,11 @@
 import { Button, ButtonText } from "@/components/ui/Button";
 import { Screen } from "@/components/ui/Screen";
+import { BOSSES_FILTERS_KEY } from "@/data/cache/keys";
+import { getWithTTL, setWithTTL } from "@/data/cache/storage";
+import { getCachedBossChances } from "@/data/chances";
+import { loadSelectedWorld } from "@/data/worlds/hooks";
 import { useNavigation } from "expo-router";
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { ScrollView, View } from "react-native";
 import styled from "styled-components/native";
 
@@ -46,16 +50,41 @@ const ChipText = styled.Text<{ selected?: boolean }>(({ theme, selected }) => ({
   fontFamily: theme.tokens.typography.fonts.body,
 }));
 
+type ChanceLabel = "Low" | "Mid" | "High" | "Lost Track" | "No Chance";
+
 export default function FilterScreen() {
   const navigation = useNavigation();
-  const [chance, setChance] = useState<"Low" | "Mid" | "High" | null>(null);
-  const [city, setCity] = useState<
-    "Venore" | "Carlin" | "Thais" | null
-  >(null);
+  const [chance, setChance] = useState<ChanceLabel | null>(null);
+  const [city, setCity] = useState<string | null>(null);
+  const [cities, setCities] = useState<string[]>([]);
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: "Filter" });
   }, [navigation]);
+
+  // Load persisted filters and dynamic cities
+  useEffect(() => {
+    (async () => {
+      const saved = await getWithTTL<any>(BOSSES_FILTERS_KEY, Number.MAX_SAFE_INTEGER);
+      if (saved) {
+        const savedChance: string | null = saved?.chance ?? null;
+        setChance(
+          savedChance === 'low' ? 'Low' : savedChance === 'medium' ? 'Mid' : savedChance === 'high' ? 'High' : null
+        );
+        setCity(typeof saved?.city === 'string' ? saved.city : null);
+      }
+
+      const world = await loadSelectedWorld();
+      if (world) {
+        const cached = await getCachedBossChances(world);
+        if (cached && cached.length) {
+          const unique = Array.from(new Set(cached.map((b) => b.city).filter((c): c is string => !!c)));
+          unique.sort((a, b) => a.localeCompare(b));
+          setCities(unique);
+        }
+      }
+    })();
+  }, []);
 
   return (
     <Screen>
@@ -63,7 +92,7 @@ export default function FilterScreen() {
         <Section>
           <SectionTitle>Chance</SectionTitle>
           <ChipRow>
-            {["Low", "Mid", "High"].map((c) => (
+            {["Low", "Mid", "High", "Lost Track", "No Chance"].map((c) => (
               <Chip
                 key={c}
                 selected={chance === (c as any)}
@@ -78,20 +107,43 @@ export default function FilterScreen() {
         <Section>
           <SectionTitle>City</SectionTitle>
           <ChipRow>
-            {["Venore", "Carlin", "Thais"].map((ct) => (
+            {cities.map((ct) => (
               <Chip
                 key={ct}
-                selected={city === (ct as any)}
-                onPress={() => setCity(city === (ct as any) ? null : (ct as any))}
+                selected={city === ct}
+                onPress={() => setCity(city === ct ? null : ct)}
               >
-                <ChipText selected={city === (ct as any)}>{ct}</ChipText>
+                <ChipText selected={city === ct}>{ct}</ChipText>
               </Chip>
             ))}
           </ChipRow>
         </Section>
 
         <View style={{ height: 8 }} />
-        <Button variant="primary" onPress={() => navigation.goBack()}>
+        <Button
+          variant="primary"
+          onPress={async () => {
+            const saved = await getWithTTL<any>(BOSSES_FILTERS_KEY, Number.MAX_SAFE_INTEGER);
+            const normalizedChance =
+              chance === 'Low'
+                ? 'low'
+                : chance === 'Mid'
+                ? 'medium'
+                : chance === 'High'
+                ? 'high'
+                : chance === 'No Chance'
+                ? 'no chance'
+                : chance === 'Lost Track'
+                ? 'lost track'
+                : null;
+            await setWithTTL(BOSSES_FILTERS_KEY, {
+              ...(saved ?? {}),
+              chance: normalizedChance,
+              city: city ?? null,
+            });
+            navigation.goBack();
+          }}
+        >
           <ButtonText>Apply</ButtonText>
         </Button>
         <View style={{ height: 24 }} />

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,6 +1,9 @@
 import { Button, ButtonText } from "@/components/ui/Button";
+import SelectModal from "@/components/ui/SelectModal";
+import { loadSelectedWorld, saveSelectedWorld, useWorlds } from '@/data/worlds/hooks';
 import { useAuth } from "@/state/auth";
 import { router } from 'expo-router';
+import { useEffect, useState } from 'react';
 import styled from "styled-components/native";
 
 const Container = styled.View(({ theme }) => ({
@@ -21,8 +24,23 @@ const Title = styled.Text(({ theme }) => ({
 const Dropdown = styled.View(({ theme }) => ({
   backgroundColor: theme.tokens.colors.card,
   borderRadius: theme.tokens.radius,
-  padding: 16,
+  padding: 12,
   marginBottom: 16,
+}));
+
+const DropdownItem = styled.Pressable(({ theme }) => ({
+  paddingVertical: 10,
+}));
+
+const DropdownText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontFamily: theme.tokens.typography.fonts.title,
+  fontSize: theme.tokens.typography.sizes.h3,
+}));
+
+const ErrorText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.danger,
+  marginTop: 8,
 }));
 
 const handleGooglePress = async (signInWithGoogle: () => Promise<void>) => {
@@ -32,14 +50,52 @@ const handleGooglePress = async (signInWithGoogle: () => Promise<void>) => {
 
 export default function Onboarding() {
   const { signInWithGoogle, isGoogleReady } = useAuth();
+  const { data: worlds, loading, error, refetch } = useWorlds();
+  const [expanded, setExpanded] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  useEffect(() => {
+    loadSelectedWorld().then((w) => { if (w) setSelected(w); });
+  }, []);
+
+  const canSignIn = !!selected && !loading && worlds.length > 0 && isGoogleReady;
+
   return (
     <Container>
-      <Title>Tibia Boss Tracker</Title>
+      <Title>Tibia Bosses Tracker</Title>
+      
       <Dropdown>
-        <Title style={{ fontSize: 16, marginBottom: 0 }}>World: Venebra</Title>
+        <Title style={{ fontSize: 16, marginBottom: 8 }}>World:</Title>
+
+        <DropdownText
+          onPress={() => { if (!loading && !error) setPickerOpen(true); }}
+          accessibilityRole="button"
+          accessibilityLabel="Select world"
+        >
+          {loading ? 'Loading worlds…' : selected ?? 'Select world'}
+        </DropdownText>
+
+        {!!error && (
+          <>
+            <ErrorText>{error}</ErrorText>
+            <DropdownItem onPress={refetch}>
+              <DropdownText>Retry</DropdownText>
+            </DropdownItem>
+          </>
+        )}
       </Dropdown>
+
+      <SelectModal
+        visible={pickerOpen}
+        title="Choose your world"
+        data={worlds}
+        onSelect={async (w) => { setSelected(w); await saveSelectedWorld(w); }}
+        onClose={() => setPickerOpen(false)}
+      />
+      
       <Button variant="primary" onPress={() => handleGooglePress(signInWithGoogle)}
-        disabled={!isGoogleReady}>
+        disabled={!canSignIn}>
         <ButtonText>Sign in with Google</ButtonText>
       </Button>
     </Container>

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonText } from "@/components/ui/Button";
 import SelectModal from "@/components/ui/SelectModal";
 import { loadSelectedWorld, saveSelectedWorld, useWorlds } from '@/data/worlds/hooks';
 import { useAuth } from "@/state/auth";
-import { router } from 'expo-router';
+import { Redirect } from 'expo-router';
 import { useEffect, useState } from 'react';
 import styled from "styled-components/native";
 
@@ -45,11 +45,10 @@ const ErrorText = styled.Text(({ theme }) => ({
 
 const handleGooglePress = async (signInWithGoogle: () => Promise<void>) => {
   await signInWithGoogle();
-  router.replace('/bosses');
 };
 
 export default function Onboarding() {
-  const { signInWithGoogle, isGoogleReady } = useAuth();
+  const { user, initializing, signInWithGoogle, isGoogleReady } = useAuth();
   const { data: worlds, loading, error, refetch } = useWorlds();
   const [expanded, setExpanded] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
@@ -60,6 +59,8 @@ export default function Onboarding() {
   }, []);
 
   const canSignIn = !!selected && !loading && worlds.length > 0 && isGoogleReady;
+
+  if (!initializing && user) return <Redirect href="/bosses" />;
 
   return (
     <Container>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,6 +1,9 @@
 // app/settings.tsx
 import { Screen } from '@/components/ui/Screen';
-import styled from "styled-components/native";
+import SelectModal from '@/components/ui/SelectModal';
+import { loadSelectedWorld, saveSelectedWorld, useWorlds } from '@/data/worlds/hooks';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components/native';
 
 const Row = styled.View(({ theme }) => ({
   backgroundColor: theme.tokens.colors.card,
@@ -13,23 +16,74 @@ const Label = styled.Text(({ theme }) => ({
   color: theme.tokens.colors.text,
 }));
 
+const ValueButton = styled.Pressable(({ theme }) => ({
+  marginTop: 8,
+  paddingVertical: 12,
+  borderRadius: theme.tokens.radius,
+  backgroundColor: theme.tokens.colors.backgroundDark,
+  alignItems: 'center',
+  justifyContent: 'center',
+}));
+
+const ValueText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontFamily: theme.tokens.typography.fonts.body,
+}));
+
 export const options = { title: 'Settings' };
 
 export default function Settings() {
+  const { data: worlds, loading, error, refetch } = useWorlds();
+  const [selected, setSelected] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  useEffect(() => {
+    loadSelectedWorld().then((w) => { if (w) setSelected(w); });
+  }, []);
+
+  const canOpenPicker = !loading && !error && worlds.length > 0;
+
   return (
     <Screen>
       <Row>
-        <Label>Notifications</Label>
+        <Label>World</Label>
+
+        <ValueButton
+          disabled={!canOpenPicker}
+          onPress={() => setPickerOpen(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Choose world"
+        >
+          <ValueText>
+            {loading ? 'Loading…' : selected ?? 'Select world'}
+          </ValueText>
+        </ValueButton>
+
+        {!!error && (
+          <ValueButton onPress={refetch}>
+            <ValueText>Retry</ValueText>
+          </ValueButton>
+        )}
       </Row>
-      <Row>
-        <Label>World: Venebra</Label>
-      </Row>
+
       <Row>
         <Label>Language</Label>
       </Row>
+
       <Row>
         <Label>About</Label>
       </Row>
+
+      <SelectModal
+        visible={pickerOpen}
+        title="Choose your world"
+        data={worlds}
+        onSelect={async (w) => {
+          setSelected(w);
+          await saveSelectedWorld(w);
+        }}
+        onClose={() => setPickerOpen(false)}
+      />
     </Screen>
   );
 }

--- a/components/ui/BossListItem.tsx
+++ b/components/ui/BossListItem.tsx
@@ -12,6 +12,7 @@ export type BossListItemProps = {
     chance: Chance;
     imageUrl: string;            // e.g., getBossImageUrl(name)
     onPress: () => void;
+    killed?: boolean;
 };
 
 const Card = styled(Pressable)(({ theme }) => ({
@@ -78,6 +79,10 @@ const Muted = styled.Text(({ theme }) => ({
     fontSize: 14,
 }));
 
+const Badges = styled.View({
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+});
 const Badge = styled.View<{ bg: string }>(({ bg }) => ({
     paddingVertical: 4,
     paddingHorizontal: 10,
@@ -91,6 +96,21 @@ const BadgeText = styled.Text({
     textTransform: 'uppercase',
     fontSize: 12,
 });
+
+const KilledChip = styled.View(({ theme }) => ({
+    backgroundColor: theme.tokens.colors.danger,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+    marginTop: 8,
+    alignSelf: 'flex-start',
+}));
+
+const KilledChipText = styled.Text(() => ({
+    color: '#111',
+    fontWeight: '700',
+    fontSize: 12,
+}));
 
 function chanceColor(theme: any, chance: Chance) {
     switch (chance) {
@@ -115,6 +135,7 @@ export function BossListItem({
     chance,
     imageUrl,
     onPress,
+    killed = false,
 }: BossListItemProps) {
     return (
         <Card onPress={onPress}>
@@ -124,9 +145,16 @@ export function BossListItem({
                     <TitleWrap>
                         <Name numberOfLines={1} ellipsizeMode="tail">{name}</Name>
                     </TitleWrap>
-                    <Badge bg={chanceColor({ tokens: { colors: { success: '#4CAF50', warning: '#FF9800' } } }, chance)}>
-                        <BadgeText>{chance}</BadgeText>
-                    </Badge>
+                    <Badges>
+                        <Badge bg={chanceColor({ tokens: { colors: { success: '#4CAF50', warning: '#FF9800' } } }, chance)}>
+                            <BadgeText>{chance}</BadgeText>
+                        </Badge>
+                        {killed ? (
+                            <KilledChip accessibilityLabel="Marked as killed">
+                                <KilledChipText>Marked as Killed</KilledChipText>
+                            </KilledChip>
+                        ) : null}
+                    </Badges>
                 </Row>
 
                 {city ? <City>{city}</City> : null}

--- a/components/ui/BossListItem.tsx
+++ b/components/ui/BossListItem.tsx
@@ -112,6 +112,12 @@ const KilledChipText = styled.Text(() => ({
     fontSize: 12,
 }));
 
+// New left column groups name, city and last-seen
+const Left = styled.View({
+    flex: 1,
+    minWidth: 0,
+});
+
 function chanceColor(theme: any, chance: Chance) {
     switch (chance) {
         case 'high':
@@ -142,9 +148,17 @@ export function BossListItem({
             <Avatar source={{ uri: imageUrl }} contentFit="contain" />
             <Info>
                 <Row>
-                    <TitleWrap>
-                        <Name numberOfLines={1} ellipsizeMode="tail">{name}</Name>
-                    </TitleWrap>
+                    <Left>
+                        <TitleWrap>
+                            <Name numberOfLines={1} ellipsizeMode="tail">{name}</Name>
+                        </TitleWrap>
+                        {city ? <City numberOfLines={1} ellipsizeMode="tail">{city}</City> : null}
+                        <Meta>
+                            {typeof daysSince === 'number' ? (
+                                <Muted>last seen {daysSince === 0 ? 'today' : `${daysSince}d ago`}</Muted>
+                            ) : null}
+                        </Meta>
+                    </Left>
                     <Badges>
                         <Badge bg={chanceColor({ tokens: { colors: { success: '#4CAF50', warning: '#FF9800' } } }, chance)}>
                             <BadgeText>{chance}</BadgeText>
@@ -156,15 +170,6 @@ export function BossListItem({
                         ) : null}
                     </Badges>
                 </Row>
-
-                {city ? <City>{city}</City> : null}
-
-                <Meta>
-                    {typeof daysSince === 'number' ? (
-                        <Muted>last seen {daysSince === 0 ? 'today' : `${daysSince}d ago`}</Muted>
-                    ) : null}
-                    {/* Add more muted bits later (e.g., region) */}
-                </Meta>
             </Info>
         </Card >
     );

--- a/components/ui/BossListItem.tsx
+++ b/components/ui/BossListItem.tsx
@@ -1,0 +1,143 @@
+// components/ui/BossListItem.tsx
+import { Image } from 'expo-image';
+import { Pressable } from 'react-native';
+import styled from 'styled-components/native';
+
+type Chance = 'high' | 'medium' | 'low' | 'no chance' | 'lost track';
+
+export type BossListItemProps = {
+    name: string;
+    city?: string | null;
+    daysSince?: number | null;
+    chance: Chance;
+    imageUrl: string;            // e.g., getBossImageUrl(name)
+    onPress: () => void;
+};
+
+const Card = styled(Pressable)(({ theme }) => ({
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.tokens.colors.card,
+    borderRadius: theme.tokens.radius,
+    padding: 12,
+    marginBottom: 12,
+    // nice subtle shadow/glow
+    shadowColor: '#000',
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+}));
+
+const Avatar = styled(Image)(({ theme }) => ({
+    width: 56,
+    height: 56,
+    borderRadius: theme.tokens.radius,
+    marginRight: 12,
+}));
+
+const Info = styled.View({
+    flex: 1,
+});
+
+const Row = styled.View({
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+});
+
+// add this helper wrapper
+const TitleWrap = styled.View({
+    flex: 1,
+    minWidth: 0,      // <- allows shrinking inside a row
+    paddingRight: 8,
+});
+
+const Name = styled.Text(({ theme }) => ({
+    color: theme.tokens.colors.text,
+    fontFamily: theme.tokens.typography.fonts.title,
+    fontSize: theme.tokens.typography.sizes.h3,
+    flexShrink: 1,    // <- let it truncate instead of pushing the badge
+}));
+
+
+const City = styled.Text(({ theme }) => ({
+    color: theme.tokens.colors.textSecondary,
+    marginTop: 4,
+}));
+
+const Meta = styled.View({
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 6,
+});
+
+const Muted = styled.Text(({ theme }) => ({
+    color: theme.tokens.colors.textSecondary,
+    fontSize: 14,
+}));
+
+const Badge = styled.View<{ bg: string }>(({ bg }) => ({
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: bg,
+}));
+
+const BadgeText = styled.Text({
+    color: '#111',
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    fontSize: 12,
+});
+
+function chanceColor(theme: any, chance: Chance) {
+    switch (chance) {
+        case 'high':
+            return theme.tokens.colors.success; // green
+        case 'medium':
+            return theme.tokens.colors.warning; // yellow
+        case 'low':
+            return '#7a7a7a';                   // gray
+        case 'no chance':
+            return '#b94a48';                   // red-ish
+        case 'lost track':
+        default:
+            return '#555';                      // dark gray
+    }
+}
+
+export function BossListItem({
+    name,
+    city,
+    daysSince,
+    chance,
+    imageUrl,
+    onPress,
+}: BossListItemProps) {
+    return (
+        <Card onPress={onPress}>
+            <Avatar source={{ uri: imageUrl }} contentFit="contain" />
+            <Info>
+                <Row>
+                    <TitleWrap>
+                        <Name numberOfLines={1} ellipsizeMode="tail">{name}</Name>
+                    </TitleWrap>
+                    <Badge bg={chanceColor({ tokens: { colors: { success: '#28a745', warning: '#ffc107' } } }, chance)}>
+                        <BadgeText>{chance}</BadgeText>
+                    </Badge>
+                </Row>
+
+                {city ? <City>{city}</City> : null}
+
+                <Meta>
+                    {typeof daysSince === 'number' ? (
+                        <Muted>last seen {daysSince === 0 ? 'today' : `${daysSince}d ago`}</Muted>
+                    ) : null}
+                    {/* Add more muted bits later (e.g., region) */}
+                </Meta>
+            </Info>
+        </Card >
+    );
+}

--- a/components/ui/BossListItem.tsx
+++ b/components/ui/BossListItem.tsx
@@ -124,7 +124,7 @@ export function BossListItem({
                     <TitleWrap>
                         <Name numberOfLines={1} ellipsizeMode="tail">{name}</Name>
                     </TitleWrap>
-                    <Badge bg={chanceColor({ tokens: { colors: { success: '#28a745', warning: '#ffc107' } } }, chance)}>
+                    <Badge bg={chanceColor({ tokens: { colors: { success: '#4CAF50', warning: '#FF9800' } } }, chance)}>
                         <BadgeText>{chance}</BadgeText>
                     </Badge>
                 </Row>

--- a/components/ui/BossStatusModal.tsx
+++ b/components/ui/BossStatusModal.tsx
@@ -43,11 +43,11 @@ export default function BossStatusModal() {
   return (
     <Overlay onTouchEnd={() => close("bossStatus")}>
       <Dialog>
-        <Title>Boss Killed?</Title>
-        <Hint>Choose how to update this boss status.</Hint>
+        <Title>Boss Status</Title>
+        <Hint>What happened when you checked this boss? Choose an option below so we can update the records.</Hint>
 
         <Button variant="secondary" onPress={() => close("bossStatus")}>
-          <ButtonText>Notify Others</ButtonText>
+          <ButtonText>Boss Found – Notify Others</ButtonText>
         </Button>
 
         <Button
@@ -55,7 +55,7 @@ export default function BossStatusModal() {
           onPress={() => close("bossStatus")}
           style={{ marginTop: 8 }}
         >
-          <ButtonText>Mark as Dead</ButtonText>
+          <ButtonText>Boss Defeated</ButtonText>
         </Button>
 
         <Button
@@ -63,7 +63,7 @@ export default function BossStatusModal() {
           onPress={() => close("bossStatus")}
           style={{ marginTop: 8 }}
         >
-          <ButtonText>Mark as Watched</ButtonText>
+          <ButtonText>No Boss Found</ButtonText>
         </Button>
       </Dialog>
     </Overlay>

--- a/components/ui/BossStatusModal.tsx
+++ b/components/ui/BossStatusModal.tsx
@@ -1,6 +1,9 @@
 // components/ui/BossStatusModal.tsx
 import { Button, ButtonText } from "@/components/ui/Button";
+import { loadSelectedWorld } from "@/data/worlds/hooks";
+import { submitSighting } from "@/services/firestore";
 import { useModals } from "@/state/modals";
+import * as Haptics from 'expo-haptics';
 import { Pressable } from "react-native";
 import styled from "styled-components/native";
 
@@ -40,19 +43,32 @@ export default function BossStatusModal() {
 
   if (!visible) return null;
 
+  async function handleSubmit(status: 'spotted' | 'killed' | 'checked') {
+    try {
+      const world = await loadSelectedWorld();
+      if (!world) throw new Error('Select a world first');
+      await submitSighting({ world, bossName: bossStatus!.bossName, status });
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    } catch (e) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+    } finally {
+      close("bossStatus");
+    }
+  }
+
   return (
     <Overlay onTouchEnd={() => close("bossStatus")}>
       <Dialog>
         <Title>Boss Status</Title>
         <Hint>What happened when you checked this boss? Choose an option below so we can update the records.</Hint>
 
-        <Button variant="secondary" onPress={() => close("bossStatus")}>
+        <Button variant="secondary" onPress={() => handleSubmit('spotted')}>
           <ButtonText>Boss Found – Notify Others</ButtonText>
         </Button>
 
         <Button
           variant="destructive"
-          onPress={() => close("bossStatus")}
+          onPress={() => handleSubmit('killed')}
           style={{ marginTop: 8 }}
         >
           <ButtonText>Boss Defeated</ButtonText>
@@ -60,7 +76,7 @@ export default function BossStatusModal() {
 
         <Button
           variant="primary"
-          onPress={() => close("bossStatus")}
+          onPress={() => handleSubmit('checked')}
           style={{ marginTop: 8 }}
         >
           <ButtonText>No Boss Found</ButtonText>

--- a/components/ui/LootRow.tsx
+++ b/components/ui/LootRow.tsx
@@ -1,0 +1,190 @@
+// components/ui/LootRow.tsx
+import * as Haptics from "expo-haptics";
+import { Image } from "expo-image";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FlatList, Pressable } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from "react-native-reanimated";
+import styled from "styled-components/native";
+
+import { getLootImageUrl } from "@/utils/images";
+
+export type LootRowProps = {
+  items: string[];
+  onSelect?: (name: string | null) => void;
+};
+
+export function toggleSelection(current: string | null, next: string): string | null {
+  return current === next ? null : next;
+}
+
+const RowContainer = styled.View(({ theme }) => ({
+  width: "100%",
+  alignItems: "center",
+}));
+
+const Content = styled.View(({ theme }) => ({
+  flexDirection: "row",
+  alignItems: "center",
+}));
+
+const TileContainer = styled(Animated.View)(({ theme }) => ({
+  width: 72,
+  height: 72,
+  borderRadius: theme.tokens.radius,
+  backgroundColor: theme.tokens.colors.card,
+  marginHorizontal: theme.tokens.spacing(0.5),
+  alignItems: "center",
+  justifyContent: "center",
+  borderWidth: 1,
+  borderColor: "rgba(255,255,255,0.06)",
+  shadowColor: "#000",
+  shadowOpacity: 0.35,
+  shadowRadius: 8,
+  shadowOffset: { width: 0, height: 4 },
+  elevation: 3,
+  overflow: "hidden",
+}));
+
+const LootImage = styled(Image)(({ theme }) => ({
+  width: 56,
+  height: 56,
+}));
+
+const Tooltip = styled(Animated.View)(({ theme }) => ({
+  position: "absolute",
+  bottom: 80,
+  paddingVertical: 6,
+  paddingHorizontal: 10,
+  borderRadius: 999,
+  backgroundColor: "rgba(0,0,0,0.8)",
+  borderWidth: 1,
+  borderColor: "rgba(255,255,255,0.08)",
+}));
+
+const TooltipText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontSize: 12,
+}));
+
+type TileProps = {
+  name: string;
+  selected: boolean;
+  onToggle: (name: string) => void;
+};
+
+const LootTile = memo(function LootTile({ name, selected, onToggle }: TileProps) {
+  const scale = useSharedValue(1);
+  const tooltipOpacity = useSharedValue(0);
+  const tooltipScale = useSharedValue(0.95);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const borderAnimatedStyle = useAnimatedStyle(() => ({
+    borderColor: withTiming(selected ? "rgba(255,215,0,0.45)" : "rgba(255,255,255,0.06)", { duration: 120 }),
+  }));
+
+  const tooltipStyle = useAnimatedStyle(() => ({
+    opacity: tooltipOpacity.value,
+    transform: [{ scale: tooltipScale.value }],
+  }));
+
+  const handlePressIn = () => {
+    scale.value = withSpring(0.96, { damping: 14, stiffness: 180 });
+  };
+  const handlePressOut = () => {
+    scale.value = withSpring(1, { damping: 14, stiffness: 180 });
+  };
+
+  const handlePress = async () => {
+    onToggle(name);
+    Haptics.selectionAsync();
+  };
+
+  const handleLongPress = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    tooltipOpacity.value = withTiming(1, { duration: 150 });
+    tooltipScale.value = withTiming(1, { duration: 150 });
+    timeoutRef.current = setTimeout(() => {
+      tooltipOpacity.value = withTiming(0, { duration: 180 });
+      tooltipScale.value = withTiming(0.95, { duration: 180 });
+    }, 1500);
+  };
+
+  useEffect(() => () => { if (timeoutRef.current) clearTimeout(timeoutRef.current); }, []);
+
+  return (
+    <Pressable
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+      accessibilityRole="imagebutton"
+      accessibilityLabel={name}
+    >
+      <TileContainer style={[animatedStyle, borderAnimatedStyle]}>
+        <LootImage
+          source={{ uri: getLootImageUrl(name) }}
+          contentFit="contain"
+          cachePolicy="memory-disk"
+        />
+        <Tooltip style={tooltipStyle} pointerEvents="none">
+          <TooltipText>{name}</TooltipText>
+        </Tooltip>
+      </TileContainer>
+    </Pressable>
+  );
+});
+
+export const LootRow: React.FC<LootRowProps> = ({ items, onSelect }) => {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // Preload images for smoother experience
+  useEffect(() => {
+    items.forEach((name) => {
+      const url = getLootImageUrl(name);
+      Image.prefetch?.(url);
+    });
+  }, [items]);
+
+  const onToggle = useCallback(
+    (name: string) => {
+      setSelected((current) => {
+        const next = toggleSelection(current, name);
+        onSelect?.(next);
+        return next;
+      });
+    },
+    [onSelect]
+  );
+
+  const keyExtractor = useCallback((n: string) => n, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: string }) => (
+      <LootTile name={item} selected={selected === item} onToggle={onToggle} />
+    ),
+    [onToggle, selected]
+  );
+
+  const data = useMemo(() => items ?? [], [items]);
+
+  return (
+    <RowContainer>
+      <FlatList
+        data={data}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingHorizontal: 8, alignItems: "center" }}
+      />
+    </RowContainer>
+  );
+};
+
+export default memo(LootRow);
+
+

--- a/components/ui/Screen.tsx
+++ b/components/ui/Screen.tsx
@@ -1,5 +1,6 @@
 import { useHeaderHeight } from "@react-navigation/elements";
 import { ReactNode } from "react";
+import { ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
@@ -7,6 +8,7 @@ interface ScreenProps {
   children: ReactNode;
   padding?: number;
   withHeaderOffset?: boolean; // default: true
+  scrollable?: boolean; // default: false
 }
 
 const Container = styled(SafeAreaView)<{ padding?: number }>(
@@ -21,6 +23,7 @@ export function Screen({
   children,
   padding,
   withHeaderOffset = true,
+  scrollable = false,
 }: ScreenProps) {
   const headerHeight = useHeaderHeight(); // respeita iOS/Android
   return (
@@ -30,7 +33,17 @@ export function Screen({
       padding={padding}
       style={withHeaderOffset ? { paddingTop: headerHeight + 8 } : undefined}
     >
-      {children}
+      {scrollable ? (
+        <ScrollView
+          style={{ flex: 1 }}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={{ paddingBottom: 16 }}
+        >
+          {children}
+        </ScrollView>
+      ) : (
+        children
+      )}
     </Container>
   );
 }

--- a/components/ui/SelectModal.tsx
+++ b/components/ui/SelectModal.tsx
@@ -1,0 +1,71 @@
+// components/ui/SelectModal.tsx
+import { FlatList, Modal, Pressable, View } from 'react-native';
+import styled from 'styled-components/native';
+
+const Overlay = styled(Pressable)(() => ({
+  flex: 1,
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  justifyContent: 'center',
+  alignItems: 'center',
+}));
+
+const Panel = styled.View(({ theme }) => ({
+  width: '88%',
+  maxHeight: 420, // scrolls if content exceeds this height
+  backgroundColor: theme.tokens.colors.card,
+  borderRadius: theme.tokens.radius,
+  padding: 16,
+}));
+
+const Title = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontFamily: theme.tokens.typography.fonts.title,
+  fontSize: theme.tokens.typography.sizes.h3,
+  textAlign: 'center',
+  marginBottom: 8,
+}));
+
+const Item = styled.Pressable(({ theme }) => ({
+  paddingVertical: 12,
+  borderBottomWidth: 1,
+  borderBottomColor: theme.tokens.colors.backgroundDark,
+}));
+
+const ItemText = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+  fontSize: theme.tokens.typography.sizes.body,
+  fontFamily: theme.tokens.typography.fonts.body,
+}));
+
+type Props = {
+  visible: boolean;
+  title?: string;
+  data: string[];
+  onSelect: (value: string) => void;
+  onClose: () => void;
+};
+
+export default function SelectModal({ visible, title = 'Select', data, onSelect, onClose }: Props) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Overlay onPress={onClose}>
+        <Pressable onPress={() => {}} style={{ width: '100%', alignItems: 'center' }}>
+          <Panel>
+            <Title>{title}</Title>
+            <FlatList
+              data={data}
+              keyExtractor={(v) => v}
+              renderItem={({ item }) => (
+                <Item onPress={() => { onSelect(item); onClose(); }}>
+                  <ItemText>{item}</ItemText>
+                </Item>
+              )}
+              ItemSeparatorComponent={() => <View style={{ height: 0 }} />}
+              showsVerticalScrollIndicator
+            />
+          </Panel>
+        </Pressable>
+      </Overlay>
+    </Modal>
+  );
+}

--- a/components/ui/SightingListItem.tsx
+++ b/components/ui/SightingListItem.tsx
@@ -1,0 +1,82 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import styled from 'styled-components/native';
+
+export type SightingStatus = 'spotted' | 'killed' | 'checked';
+
+type Props = {
+  title: string;
+  subtitle: string;
+  status: SightingStatus;
+  accessibilityHint?: string;
+};
+
+const Row = styled.View(({ theme }) => ({
+  paddingVertical: 8,
+  paddingHorizontal: 10,
+  borderRadius: theme.tokens.radius,
+  marginBottom: 6,
+  backgroundColor: theme.tokens.colors.card,
+}));
+
+const RowKilled = styled(Row)(({ theme }) => ({
+  borderLeftWidth: 3,
+  borderLeftColor: theme.tokens.colors.danger,
+  paddingLeft: 10,
+  backgroundColor: 'rgba(185,74,72,0.08)',
+}));
+
+const Line = styled.View({
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 8,
+});
+
+const Title = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.text,
+}));
+
+const Subtitle = styled.Text(({ theme }) => ({
+  color: theme.tokens.colors.textSecondary,
+}));
+
+const KilledTag = styled.View(({ theme }) => ({
+  backgroundColor: theme.tokens.colors.danger,
+  paddingHorizontal: 8,
+  paddingVertical: 2,
+  borderRadius: 999,
+}));
+
+const KilledTagText = styled.Text(() => ({
+  color: '#111',
+  fontWeight: '700',
+  fontSize: 12,
+}));
+
+export function SightingListItem({ title, subtitle, status, accessibilityHint }: Props) {
+  if (status === 'killed') {
+    return (
+      <RowKilled accessibilityHint={accessibilityHint ?? 'Killed'}>
+        <Line>
+          <Ionicons name="skull-outline" size={16} color="#b94a48" />
+          <Title>{title}</Title>
+          <KilledTag>
+            <KilledTagText>Killed</KilledTagText>
+          </KilledTag>
+        </Line>
+        <Subtitle style={{ marginTop: 2 }}>{subtitle}</Subtitle>
+      </RowKilled>
+    );
+  }
+
+  return (
+    <Row>
+      <Title>{title}</Title>
+      <Subtitle style={{ marginTop: 2 }}>{subtitle}</Subtitle>
+    </Row>
+  );
+}
+
+export default SightingListItem;
+
+

--- a/components/ui/StaticTibiaMap.tsx
+++ b/components/ui/StaticTibiaMap.tsx
@@ -1,0 +1,74 @@
+// app/components/StaticTibiaMap.tsx
+import { View } from 'react-native';
+import { WebView } from 'react-native-webview';
+
+type Props = { coord: string; height?: number };
+
+export default function StaticTibiaMap({ coord, height = 300 }: Props) {
+  // garante formato x,y,z:zoom
+  const hash = coord.includes(':')
+    ? coord.trim()
+    : (() => { const [x,y,z,zoom='0']=coord.replace(/\s+/g,'').split(','); return `${x},${y},${z}:${zoom}`; })();
+
+  const html = `
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"/>
+<link rel="stylesheet" href="https://tibiamaps.io/_css/map.css">
+<style>
+  html,body,#map{height:100%;margin:0}
+  body{overscroll-behavior:none}
+</style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <script>
+    // 1) Defina o hash ANTES de carregar o script
+    window.location.hash = "#${hash}";
+  </script>
+
+  <script src="https://tibiamaps.io/_js/map.js"
+          onload="
+            // 2) Após carregar, reforça o hash e dispara o evento para quem escuta
+            try {
+              window.location.hash = '#${hash}';
+              window.dispatchEvent(new HashChangeEvent('hashchange'));
+            } catch(e) {}
+            // 3) Tenta desabilitar via API (se o objeto 'map' existir)
+            (function lock(){
+              if (window.map) {
+                try{
+                  map.dragging && map.dragging.disable();
+                  map.touchZoom && map.touchZoom.disable();
+                  map.scrollWheelZoom && map.scrollWheelZoom.disable();
+                  map.doubleClickZoom && map.doubleClickZoom.disable();
+                  map.boxZoom && map.boxZoom.disable();
+                  map.keyboard && map.keyboard.disable();
+                  map.tap && map.tap.disable();
+                  map.zoomControl && map.zoomControl.remove();
+                }catch(e){}
+              } else { setTimeout(lock,80); }
+            })();
+          ">
+  </script>
+</body>
+</html>`.trim();
+
+  return (
+    <View style={{ width: '100%', height }}>
+      <WebView
+        originWhitelist={['*']}
+        source={{ html }}
+        javaScriptEnabled
+        domStorageEnabled
+        bounces={false}
+        style={{ backgroundColor: 'transparent' }}
+        // IMPORTANTE: remonta o WebView quando 'coord' muda
+        key={hash}
+      />
+    </View>
+  );
+}

--- a/components/ui/TimelinePanel.tsx
+++ b/components/ui/TimelinePanel.tsx
@@ -44,6 +44,12 @@ const Row = styled.View(({ theme }) => ({
   borderBottomColor: theme.tokens.colors.backgroundDark,
 }));
 
+const RowKilled = styled(Row)(({ theme }) => ({
+  borderLeftWidth: 3,
+  borderLeftColor: theme.tokens.colors.danger,
+  paddingLeft: 10,
+}));
+
 const Primary = styled.Text(({ theme }) => ({
   color: theme.tokens.colors.text,
   fontSize: theme.tokens.typography.sizes.body,
@@ -90,12 +96,23 @@ export default function TimelinePanel() {
             keyExtractor={(i) => i.id}
             contentInsetAdjustmentBehavior="automatic"
             renderItem={({ item }) => (
-              <Row>
-                <Primary>{item.bossName}</Primary>
-                <Secondary>
-                  {item.playerName ?? 'Someone'} • {item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}
-                </Secondary>
-              </Row>
+              item.status === 'killed' ? (
+                <RowKilled accessibilityHint="Killed">
+                  <Primary>
+                    {item.bossName} <Primary style={{ color: '#b94a48', fontWeight: '700' }}>Killed</Primary>
+                  </Primary>
+                  <Secondary>
+                    {item.playerName ?? 'Someone'} • {item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}
+                  </Secondary>
+                </RowKilled>
+              ) : (
+                <Row>
+                  <Primary>{item.bossName}</Primary>
+                  <Secondary>
+                    {item.playerName ?? 'Someone'} • {item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}
+                  </Secondary>
+                </Row>
+              )
             )}
           />
         </PanelSafeArea>

--- a/components/ui/TimelinePanel.tsx
+++ b/components/ui/TimelinePanel.tsx
@@ -1,4 +1,5 @@
 // components/ui/TimelinePanel.tsx
+import SightingListItem from '@/components/ui/SightingListItem';
 import { useRecentSightings } from '@/data/sightings/hooks';
 import { timeAgo } from '@/data/time';
 import { loadSelectedWorld } from '@/data/worlds/hooks';
@@ -96,23 +97,12 @@ export default function TimelinePanel() {
             keyExtractor={(i) => i.id}
             contentInsetAdjustmentBehavior="automatic"
             renderItem={({ item }) => (
-              item.status === 'killed' ? (
-                <RowKilled accessibilityHint="Killed">
-                  <Primary>
-                    {item.bossName} <Primary style={{ color: '#b94a48', fontWeight: '700' }}>Killed</Primary>
-                  </Primary>
-                  <Secondary>
-                    {item.playerName ?? 'Someone'} • {item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}
-                  </Secondary>
-                </RowKilled>
-              ) : (
-                <Row>
-                  <Primary>{item.bossName}</Primary>
-                  <Secondary>
-                    {item.playerName ?? 'Someone'} • {item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}
-                  </Secondary>
-                </Row>
-              )
+              <SightingListItem
+                status={item.status as any}
+                title={item.bossName}
+                subtitle={`${item.playerName ?? 'Someone'} • ${item.createdAt ? timeAgo(item.createdAt.toDate?.() ?? new Date()) : 'just now'}`}
+                accessibilityHint={item.status === 'killed' ? 'Killed' : undefined}
+              />
             )}
           />
         </PanelSafeArea>

--- a/data/cache/keys.ts
+++ b/data/cache/keys.ts
@@ -1,4 +1,8 @@
 export const WORLD_LIST_KEY = 'worlds:list:v1';
 export const SELECTED_WORLD_KEY = 'user:selectedWorld';
 
+// Boss chances cache prefix. Full key will be `${BOSS_CHANCES_KEY_PREFIX}:${world}:${yyyy-mm-dd}`
+export const BOSS_CHANCES_KEY_PREFIX = 'bosses:chances:v1';
+export const BOSS_CHANCES_LATEST_KEY_PREFIX = 'bosses:chances:latest:v1';
+
 

--- a/data/cache/keys.ts
+++ b/data/cache/keys.ts
@@ -5,4 +5,7 @@ export const SELECTED_WORLD_KEY = 'user:selectedWorld';
 export const BOSS_CHANCES_KEY_PREFIX = 'bosses:chances:v1';
 export const BOSS_CHANCES_LATEST_KEY_PREFIX = 'bosses:chances:latest:v1';
 
+// Persisted filters/search for bosses list
+export const BOSSES_FILTERS_KEY = 'bosses:filters:v1';
+
 

--- a/data/cache/keys.ts
+++ b/data/cache/keys.ts
@@ -1,0 +1,4 @@
+export const WORLD_LIST_KEY = 'worlds:list:v1';
+export const SELECTED_WORLD_KEY = 'user:selectedWorld';
+
+

--- a/data/cache/storage.ts
+++ b/data/cache/storage.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+type CacheEntry<T> = { value: T; ts: number };
+
+export async function setWithTTL<T>(key: string, value: T): Promise<void> {
+  const entry: CacheEntry<T> = { value, ts: Date.now() };
+  await AsyncStorage.setItem(key, JSON.stringify(entry));
+}
+
+export async function getWithTTL<T>(key: string, maxAgeMs: number): Promise<T | null> {
+  const raw = await AsyncStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as CacheEntry<T>;
+    if (typeof parsed?.ts !== 'number') return null;
+    if (Date.now() - parsed.ts > maxAgeMs) return null;
+    return parsed.value as T;
+  } catch {
+    return null;
+  }
+}
+
+

--- a/data/chances.ts
+++ b/data/chances.ts
@@ -1,0 +1,115 @@
+// data/chances.ts
+import { BOSS_CHANCES_KEY_PREFIX } from './cache/keys';
+import { getWithTTL, setWithTTL } from './cache/storage';
+
+export type BossChanceLevel = 'high' | 'medium' | 'low' | 'Lost Track' | 'no chance';
+
+export type BossChanceItem = {
+  // id may be absent in API; derive from name when needed
+  id?: string;
+  name: string;
+  start_day?: number;
+  end_day?: number;
+  city?: string;
+  location?: string[];
+  loots?: string[];
+  lastSeen?: string;
+  daysSince?: number;
+  chance: BossChanceLevel;
+};
+
+export type BossChances = BossChanceItem[];
+
+function deriveIdFromName(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  return name.toLowerCase().replace(/\s+/g, '');
+}
+
+function normalizeBoss(input: any): BossChanceItem {
+  const name: string = input?.name ?? 'Unknown';
+  const id: string | undefined = input?.id ?? deriveIdFromName(name);
+  return {
+    id,
+    name,
+    start_day: typeof input?.start_day === 'number' ? input.start_day : undefined,
+    end_day: typeof input?.end_day === 'number' ? input.end_day : undefined,
+    city: typeof input?.city === 'string' ? input.city : undefined,
+    location: Array.isArray(input?.location) ? (input.location as string[]) : undefined,
+    loots: Array.isArray(input?.loots) ? (input.loots as string[]) : undefined,
+    lastSeen: typeof input?.lastSeen === 'string' ? input.lastSeen : undefined,
+    daysSince: typeof input?.daysSince === 'number' ? input.daysSince : undefined,
+    chance: (input?.chance as BossChanceLevel) ?? 'no chance',
+  } as BossChanceItem;
+}
+
+function getTargetDateUTC(now: Date): string {
+  const hour = now.getUTCHours();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  if (hour < 8) {
+    d.setUTCDate(d.getUTCDate() - 1);
+  }
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function buildCacheKey(world: string, dateStr: string): string {
+  return `${BOSS_CHANCES_KEY_PREFIX}:${world}:${dateStr}`;
+}
+
+export async function fetchBossChances(world: string): Promise<{ date: string; data: BossChances }>{
+  const date = getTargetDateUTC(new Date());
+  const url = `https://raw.githubusercontent.com/ViniciusPaldes/tibia-bosses-tracker-chances/refs/heads/master/data/${encodeURIComponent(world)}/${date}.json`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to load boss chances: ${res.status}`);
+  }
+  const raw = await res.json();
+  // Expect array of objects with full fields. Be defensive to support other shapes.
+  let items: BossChances;
+  if (Array.isArray(raw)) {
+    items = (raw as any[]).map((r) => normalizeBoss(r));
+  } else if (raw && typeof raw === 'object' && Array.isArray((raw as any).items)) {
+    items = ((raw as any).items as any[]).map((r) => normalizeBoss(r));
+  } else if (raw && typeof raw === 'object') {
+    // object keyed by boss name → value can be chance or object
+    items = Object.entries(raw as Record<string, any>).map(([name, value]) => {
+      if (value && typeof value === 'object') {
+        return normalizeBoss({ name, ...value });
+      }
+      return normalizeBoss({ name, chance: value as BossChanceLevel });
+    });
+  } else {
+    items = [];
+  }
+  return { date, data: items };
+}
+
+const TTL_1_DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function getCachedBossChances(world: string): Promise<BossChances | null> {
+  const date = getTargetDateUTC(new Date());
+  return getWithTTL<BossChances>(buildCacheKey(world, date), TTL_1_DAY_MS);
+}
+
+export async function setCachedBossChances(world: string, date: string, data: BossChances): Promise<void> {
+  await setWithTTL(buildCacheKey(world, date), data);
+}
+
+export function sortBossesByChance<T extends { chance?: BossChanceLevel }>(items: T[]): T[] {
+  const order: Record<BossChanceLevel, number> = {
+    high: 1,
+    medium: 2,
+    low: 3,
+    'Lost Track': 4,
+    'no chance': 5,
+  };
+  return [...items].sort((a, b) => {
+    const ca = a.chance ? order[a.chance as BossChanceLevel] ?? 999 : 998;
+    const cb = b.chance ? order[b.chance as BossChanceLevel] ?? 999 : 998;
+    return ca - cb;
+  });
+}
+
+

--- a/data/chances.ts
+++ b/data/chances.ts
@@ -2,7 +2,7 @@
 import { BOSS_CHANCES_KEY_PREFIX } from './cache/keys';
 import { getWithTTL, setWithTTL } from './cache/storage';
 
-export type BossChanceLevel = 'high' | 'medium' | 'low' | 'Lost Track' | 'no chance';
+export type BossChanceLevel = 'high' | 'medium' | 'low' | 'lost track' | 'no chance';
 
 export type BossChanceItem = {
   // id may be absent in API; derive from name when needed
@@ -118,7 +118,7 @@ export function sortBossesByChance<T extends { chance?: BossChanceLevel }>(items
     high: 1,
     medium: 2,
     low: 3,
-    'Lost Track': 4,
+    'lost track': 4,
     'no chance': 5,
   };
   return [...items].sort((a, b) => {

--- a/data/sightings/hooks.ts
+++ b/data/sightings/hooks.ts
@@ -1,0 +1,60 @@
+import { getWithTTL, setWithTTL } from '@/data/cache/storage';
+import { db } from '@/services/firestore';
+import { collection, limit as limitQ, onSnapshot, orderBy, query, where, type DocumentData, type QuerySnapshot } from 'firebase/firestore';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Sighting } from './types';
+
+const TTL_24_HOURS_MS = 24 * 60 * 60 * 1000;
+const KEY_PREFIX = 'sightings:world:v1';
+
+function buildCacheKey(world: string) {
+  return `${KEY_PREFIX}:${world}`;
+}
+
+export function useRecentSightings(world: string | null, limit: number = 50) {
+  const [data, setData] = useState<Sighting[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const unsubRef = useRef<(() => void) | null>(null);
+
+  const mapSnapshot = useCallback((snap: QuerySnapshot<DocumentData>) => {
+    const items: Sighting[] = snap.docs.map((d) => ({ id: d.id, ...(d.data() as any) })) as Sighting[];
+    setData(items);
+    setWithTTL(buildCacheKey(world || 'unknown'), items).catch(() => {});
+  }, [world]);
+
+  const load = useCallback(async () => {
+    if (!world) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const cached = await getWithTTL<Sighting[]>(buildCacheKey(world), TTL_24_HOURS_MS);
+      if (cached && cached.length) setData(cached);
+
+      const q = query(
+        collection(db, 'sightings'),
+        where('world', '==', world),
+        orderBy('createdAt', 'desc'),
+        limitQ(limit)
+      );
+      if (unsubRef.current) unsubRef.current();
+      unsubRef.current = onSnapshot(q, mapSnapshot, (e) => setError(e.message));
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load sightings');
+    } finally {
+      setLoading(false);
+    }
+  }, [world, limit, mapSnapshot]);
+
+  useEffect(() => {
+    load();
+    return () => {
+      if (unsubRef.current) unsubRef.current();
+    };
+  }, [load]);
+
+  const refetch = useCallback(() => load(), [load]);
+  return { data, loading, error, refetch } as const;
+}
+
+

--- a/data/sightings/types.ts
+++ b/data/sightings/types.ts
@@ -1,0 +1,16 @@
+import type { Timestamp } from 'firebase/firestore';
+
+export type Sighting = {
+  id: string;
+  world: string;
+  bossName: string;
+  status: 'spotted' | 'killed' | 'checked';
+  playerId: string;
+  playerName?: string;
+  coords?: string;
+  note?: string;
+  createdAt?: Timestamp; // serverTimestamp pending
+  expiresAt: Timestamp;
+};
+
+

--- a/data/worlds/api.ts
+++ b/data/worlds/api.ts
@@ -1,0 +1,13 @@
+import type { WorldsAPI } from './types';
+
+const BASE_URL = 'https://api.tibiadata.com/v4';
+
+export async function fetchWorlds(): Promise<WorldsAPI> {
+  const res = await fetch(`${BASE_URL}/worlds`);
+  if (!res.ok) {
+    throw new Error(`Failed to load worlds: ${res.status}`);
+  }
+  return (await res.json()) as WorldsAPI;
+}
+
+

--- a/data/worlds/hooks.ts
+++ b/data/worlds/hooks.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from 'react';
+import { SELECTED_WORLD_KEY, WORLD_LIST_KEY } from '../cache/keys';
+import { getWithTTL, setWithTTL } from '../cache/storage';
+import { fetchWorlds } from './api';
+
+const TTL_90_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+function dedupeAndSort(names: string[]): string[] {
+  return Array.from(new Set(names.map((n) => n.trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+}
+
+export function useWorlds() {
+  const [data, setData] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    // cache first
+    const cached = await getWithTTL<string[]>(WORLD_LIST_KEY, TTL_90_DAYS_MS);
+    if (cached && cached.length) {
+      setData(cached);
+      setLoading(false);
+      // refresh in background
+      try {
+        const fresh = await fetchWorlds();
+        const names = dedupeAndSort(fresh.worlds.regular_worlds.map((w) => w.name));
+        await setWithTTL(WORLD_LIST_KEY, names);
+        setData(names);
+      } catch {}
+      return;
+    }
+
+    // no valid cache → fetch with one retry on transient errors
+    try {
+      const fresh = await fetchWorlds();
+      const names = dedupeAndSort(fresh.worlds.regular_worlds.map((w) => w.name));
+      await setWithTTL(WORLD_LIST_KEY, names);
+      setData(names);
+    } catch (e: any) {
+      // retry once for 5xx/network
+      try {
+        await new Promise((r) => setTimeout(r, 400));
+        const fresh2 = await fetchWorlds();
+        const names2 = dedupeAndSort(fresh2.worlds.regular_worlds.map((w) => w.name));
+        await setWithTTL(WORLD_LIST_KEY, names2);
+        setData(names2);
+      } catch (e2: any) {
+        setError(e2?.message ?? 'Failed to load worlds');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const refetch = useCallback(() => load(), [load]);
+
+  return { data: data ?? [], loading, error, refetch } as const;
+}
+
+export async function loadSelectedWorld(): Promise<string | null> {
+  const raw = await getWithTTL<string>(SELECTED_WORLD_KEY, Number.MAX_SAFE_INTEGER);
+  return raw ?? null;
+}
+
+export async function saveSelectedWorld(name: string): Promise<void> {
+  await setWithTTL(SELECTED_WORLD_KEY, name);
+}
+
+

--- a/data/worlds/types.ts
+++ b/data/worlds/types.ts
@@ -1,0 +1,8 @@
+export type WorldsAPI = {
+  worlds: {
+    regular_worlds: Array<{ name: string }>;
+    // tournament_worlds ignored
+  };
+};
+
+

--- a/services/firestore.ts
+++ b/services/firestore.ts
@@ -1,0 +1,69 @@
+import { app, auth } from '@/services/firebase';
+import {
+    addDoc,
+    collection,
+    getFirestore,
+    serverTimestamp,
+    Timestamp,
+} from 'firebase/firestore';
+
+export type SightingStatus = 'spotted' | 'killed' | 'checked';
+
+export type SubmitSightingInput = {
+  world: string;
+  bossName: string;
+  status: SightingStatus;
+  coords?: string;
+  note?: string;
+  playerName?: string;
+};
+
+export const db = getFirestore(app);
+export { Timestamp };
+
+// Simple in-memory rate limiter (per app session)
+const lastSubmitByKey: Record<string, number> = {};
+
+export async function submitSighting(input: SubmitSightingInput): Promise<string> {
+  const { world, bossName, status, coords, note, playerName } = input;
+
+  if (!world || !bossName) {
+    throw new Error('Missing required fields: world and bossName');
+  }
+
+  const allowed: SightingStatus[] = ['spotted', 'killed', 'checked'];
+  if (!allowed.includes(status)) {
+    throw new Error('Invalid status');
+  }
+
+  const uid = auth.currentUser?.uid;
+  if (!uid) {
+    throw new Error('User not authenticated');
+  }
+
+  const key = `${uid}:${bossName}`;
+  const now = Date.now();
+  const last = lastSubmitByKey[key] || 0;
+  if (now - last < 5000) {
+    throw new Error('Please wait a few seconds before submitting again');
+  }
+
+  const expiresAt = Timestamp.fromMillis(now + 24 * 60 * 60 * 1000);
+
+  const docRef = await addDoc(collection(db, 'sightings'), {
+    world,
+    bossName,
+    status,
+    coords: coords || null,
+    note: note || null,
+    playerId: uid,
+    playerName: playerName || null,
+    createdAt: serverTimestamp(),
+    expiresAt,
+  });
+
+  lastSubmitByKey[key] = now;
+  return docRef.id;
+}
+
+

--- a/services/firestore.ts
+++ b/services/firestore.ts
@@ -13,9 +13,7 @@ export type SubmitSightingInput = {
   world: string;
   bossName: string;
   status: SightingStatus;
-  coords?: string;
   note?: string;
-  playerName?: string;
 };
 
 export const db = getFirestore(app);
@@ -25,7 +23,7 @@ export { Timestamp };
 const lastSubmitByKey: Record<string, number> = {};
 
 export async function submitSighting(input: SubmitSightingInput): Promise<string> {
-  const { world, bossName, status, coords, note, playerName } = input;
+  const { world, bossName, status, note } = input;
 
   if (!world || !bossName) {
     throw new Error('Missing required fields: world and bossName');
@@ -50,14 +48,15 @@ export async function submitSighting(input: SubmitSightingInput): Promise<string
 
   const expiresAt = Timestamp.fromMillis(now + 24 * 60 * 60 * 1000);
 
+  const playerName = auth.currentUser?.displayName || (auth.currentUser?.email ? auth.currentUser.email.split('@')[0] : undefined);
+
   const docRef = await addDoc(collection(db, 'sightings'), {
     world,
     bossName,
     status,
-    coords: coords || null,
     note: note || null,
     playerId: uid,
-    playerName: playerName || null,
+    playerName,
     createdAt: serverTimestamp(),
     expiresAt,
   });

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -4,3 +4,8 @@ export function getBossImageUrl(bossName: string) {
   const fileName = bossName.trim().replace(/\s+/g, '_');
   return encodeURI(`https://www.tibiawiki.com.br/wiki/Special:FilePath/${fileName}.gif`);
 }
+
+export function getLootImageUrl(itemName: string) {
+  const fileName = itemName.trim().replace(/\s+/g, '_');
+  return encodeURI(`https://www.tibiawiki.com.br/wiki/Special:FilePath/${fileName}.gif`);
+}


### PR DESCRIPTION
This PR delivers multiple key integrations and UI improvements, making the app much closer to a feature-complete state:

### Data & API Integrations
- TibiaData Worlds API — Fetches regular worlds with a 90-day cache to minimize requests.
- Boss Chances API — Retrieves daily updated boss chances from the tibia-bosses-tracker-chances repo, including full boss detail data.
- Firestore Sightings Integration — Real-time sync of sightings per world, with special handling for killed sightings.

### UI & Navigation Improvements
- Bosses List Item — Redesigned layout to show Name + City + Days Since on the left and Chance + Killed status on the right.
- Boss Detail Screen — Shows enhanced loot layout, improved styling for killed sightings, and horizontal scroll for loot items.
- Bosses Killed Yesterday — Horizontal list displayed above the main bosses list, filtered from existing boss data.
- Search & Filters — Persistent filters with removable chips, real city list for filtering, and ability to remove filters from the main list.
- Ordering Options — New dialog from the right header button to select ordering (High→Low, Low→High, A→Z, Z→A).
- StaticTibiaMap Component — Added for future location display support.

### Auth & UX Fixes
- Fixed login redirect to correctly route to the right screen without requiring a Metro reload.
- Prevented accidental clicks during list scrolling.
- Automatically refresh bosses list when switching worlds or resuming app from background.

### Miscellaneous
- Extracted reusable UI components for consistency between Detail and Timeline.
- Minor UI tweaks and polish across multiple screens.