### PR TITLE
Add Custom Toast Notifications

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,8 +12,10 @@ import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import Toast from 'react-native-toast-message';
 import styled, { ThemeProvider as StyledThemeProvider } from 'styled-components/native';
 
+import { toastConfig } from '@/components/ui/ToastConfig';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { Sentry } from '@/services/sentry';
 import { initI18n } from '@/src/i18n';
@@ -111,6 +113,7 @@ export default Sentry.wrap(function RootLayout() {
             </Stack>
 
             {/* Global UI overlays */}
+            <Toast config={toastConfig}/>
             <BossStatusModal />
             <TimelinePanel />
             <LeftDrawer />

--- a/components/ui/BossStatusModal.tsx
+++ b/components/ui/BossStatusModal.tsx
@@ -7,6 +7,7 @@ import { useModals } from "@/state/modals";
 import * as Haptics from 'expo-haptics';
 import { useTranslation } from "react-i18next";
 import { Pressable } from "react-native";
+import Toast from 'react-native-toast-message';
 import styled from "styled-components/native";
 
 const Overlay = styled(Pressable)(() => ({
@@ -51,9 +52,22 @@ export default function BossStatusModal() {
       if (!world) throw new Error('Select a world first');
       await submitSighting({ world, bossName: bossStatus!.bossName, status });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+
+      Toast.show({
+        type: 'success',
+        position: 'bottom',
+        text1: t('bossStatusSuccess'),
+      });
+
+      
     } catch (e) {
       captureException(e, 'components/ui/BossStatusModal:handleSubmit', { status, bossName: bossStatus?.bossName });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      Toast.show({
+        type: 'error',
+        position: 'bottom',
+        text1: t('bossStatusError'),
+      });
     } finally {
       close("bossStatus");
     }

--- a/components/ui/ToastConfig.tsx
+++ b/components/ui/ToastConfig.tsx
@@ -1,0 +1,77 @@
+// components/ui/toast/config.tsx
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { View } from 'react-native';
+import { BaseToast, ToastConfig } from 'react-native-toast-message';
+import { useTheme } from 'styled-components/native';
+
+function useToastStyles() {
+    const t = useTheme();
+
+    const cardBase = {
+        borderRadius: t.tokens.radius * 1.5,
+        backgroundColor: t.tokens.colors.card, 
+        borderWidth: 2,
+        paddingVertical: 10,
+        shadowColor: '#000',
+        shadowOpacity: 0.35,
+        shadowRadius: 18,
+        shadowOffset: { width: 0, height: 10 },
+        elevation: 6,
+        opacity: 0.9,
+    };
+
+    const textTitle = {
+        fontFamily: t.tokens.typography.fonts.title,
+        fontSize: 14,
+        fontWeight: 'normal',
+        letterSpacing: 0.5,
+        color: t.tokens.colors.text,
+    };
+
+    const accents = {
+        gold: t.tokens.colors.primary,
+        green: t.tokens.colors.success ?? '#4CAF50',
+        red: t.tokens.colors.danger ?? '#F44336',
+    };
+
+    return { cardBase, textTitle, accents };
+}
+
+const CustomToast = (props: any) => {
+    const s = useToastStyles();
+
+    const getToastConfig = (type: string) => {
+        switch (type) {
+            case 'success':
+                return { color: s.accents.green, icon: 'checkmark-circle' as keyof typeof Ionicons.glyphMap };
+            case 'error':
+                return { color: s.accents.red, icon: 'warning-outline' as keyof typeof Ionicons.glyphMap };
+            case 'info':
+            default:
+                return { color: s.accents.gold, icon: 'information-circle' as keyof typeof Ionicons.glyphMap };
+        }
+    };
+
+    const config = getToastConfig(props.type);
+
+    return (
+        <BaseToast
+            {...props}
+            style={[s.cardBase, { borderColor: config.color }]}
+            contentContainerStyle={{ flexDirection: 'row', alignItems: 'center', paddingHorizontal: 14, paddingVertical: 8 }}
+            renderTrailingIcon={() => null}
+            text1Style={s.textTitle}
+            renderLeadingIcon={() => <View style={{ paddingTop: 6, paddingLeft: 12 }}><Ionicons name={config.icon} size={20} color={config.color} /></View>}
+        >
+            {props.children}
+        </BaseToast>
+    );
+};
+
+
+export const toastConfig: ToastConfig = {
+    info: (p) => <CustomToast {...p} type="info" />,
+    success: (p) => <CustomToast {...p} type="success" />,
+    error: (p) => <CustomToast {...p} type="error" />,
+};

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -56,7 +56,9 @@
   "medium": "Medium",
   "low": "Low",
   "no chance": "No Chance",
-  "Lost Track": "Lost Track"
+  "Lost Track": "Lost Track",
+  "bossStatusSuccess": "Boss status updated successfully",
+  "bossStatusError": "Failed to update boss status"
 }
 
 

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -56,7 +56,9 @@
   "medium": "Medio",
   "low": "Bajo",
   "no chance": "Sin Probabilidad",
-  "Lost Track": "Perdido"
+  "Lost Track": "Perdido",
+  "bossStatusSuccess": "Estado del boss actualizado correctamente",
+  "bossStatusError": "Error al actualizar el estado del boss"
 }
 
 

--- a/locales/pl/common.json
+++ b/locales/pl/common.json
@@ -56,7 +56,9 @@
   "medium": "Średnia",
   "low": "Niska",
   "no chance": "Brak Szansy",
-  "Lost Track": "Zaginiony"
+  "Lost Track": "Zaginiony",
+  "bossStatusSuccess": "Status bossa zaktualizowany pomyślnie",
+  "bossStatusError": "Nie udało się zaktualizować statusu bossa"
 }
 
 

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -3,7 +3,7 @@
   "world": "Mundo",
   "selectWorld": "Selecionar mundo",
   "chooseWorld": "Escolha seu mundo",
-  "loadingWorlds": "Carregando mundos…",  
+  "loadingWorlds": "Carregando mundos…",
   "titleBosses": "Bosses",
   "titleBossDetail": "Detalhes do Boss",
   "titleSettings": "Configurações",
@@ -56,7 +56,7 @@
   "medium": "Médio",
   "low": "Baixo",
   "no chance": "Sem Chance",
-  "Lost Track": "Perdido"
+  "Lost Track": "Perdido",
+  "bossStatusSuccess": "Atualizado!",
+  "bossStatusError": "Falha ao atualizar!"
 }
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
+        "react-native-toast-message": "^2.3.3",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
         "styled-components": "^6.1.19",
@@ -11945,6 +11946,16 @@
         "react-native-is-edge-to-edge": "^1.1.7",
         "warn-once": "^0.1.0"
       },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-toast-message": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/react-native-toast-message/-/react-native-toast-message-2.3.3.tgz",
+      "integrity": "sha512-4IIUHwUPvKHu4gjD0Vj2aGQzqPATiblL1ey8tOqsxOWRPGGu52iIbL8M/mCz4uyqecvPdIcMY38AfwRuUADfQQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
+    "react-native-toast-message": "^2.3.3",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "styled-components": "^6.1.19",


### PR DESCRIPTION
# Summary
This PR introduces a **custom toast notification system** built on top of [`react-native-toast-message`](https://github.com/calintamas/react-native-toast-message).  
The new `toastConfig` ensures all toast messages are styled consistently with our theme tokens and provide clear, accessible feedback to users.

## Key Changes
- **New file:** `components/ui/toast/config.tsx`
  - Implemented a `CustomToast` component using `BaseToast`.
  - Centralized toast styles (`cardBase`, `textTitle`, `accents`) with `useTheme`.
  - Added dynamic icon + border color depending on toast type:
    - **Success:** green + checkmark icon  
    - **Error:** red + warning icon  
    - **Info:** gold + info icon  
- Exported a `toastConfig` object to register with `Toast` provider.
- Ensured proper shadow, elevation, and border styling for consistent card appearance.

## Why
- Provide **user feedback** (success, error, info) in a way that matches the app’s design system.  
- Replace generic/default toast with a **branded and accessible** component.  
- Centralize theme usage to avoid repeated calls to `useTheme` across components.